### PR TITLE
Change exit code to 1 for usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	args := flag.Args()
 	if len(args) < 1 {
 		flag.Usage()
-		os.Exit(2)
+		os.Exit(1)
 	}
 	c, err := git.NewClient(*gitdir, *workdir)
 	subcommand = args[0]


### PR DESCRIPTION
This should help to make it easier to run the official git tests while making dgit more of a drop-in replacement for official git.