### PR TITLE
Add "--template" option for git init

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -23,7 +23,7 @@ func Fetch(c *git.Client, args []string) {
 	config := git.ParseConfig(file)
 	repoid := config.GetConfig("remote." + args[0] + ".url")
 	var ups git.Uploadpack
-	if repoid[0:7] == "http://" || repoid[0:8] == "https://" {
+	if strings.HasPrefix(repoid, "http://") || strings.HasPrefix(repoid, "https://") {
 		ups = &git.SmartHTTPServerRetriever{Location: repoid,
 			C: c,
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/driusan/dgit/git"
 )
@@ -18,7 +20,8 @@ func Init(c *git.Client, args []string) error {
 
 	flags.BoolVar(&opts.Bare, "bare", false, "Create bare repository")
 	flags.BoolVar(&opts.Quiet, "quiet", false, "Only print errors or warnings")
-	flags.StringVar(&opts.Template, "template", "", "Specify the template directory that will be used")
+	var template string
+	flags.StringVar(&template, "template", "", "Specify the template directory that will be used")
 	q := flags.Bool("q", false, "Alias of --quiet")
 
 	flags.Parse(args)
@@ -35,6 +38,21 @@ func Init(c *git.Client, args []string) error {
 	default:
 		flags.Usage()
 		return fmt.Errorf("Invalid init command. Must only provide one directory.")
+	}
+
+	if template != "" {
+		if !filepath.IsAbs(template) {
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			template = filepath.Join(wd, template)
+		}
+		templDir, err := os.Open(template)
+		if err != nil {
+			return err
+		}
+		opts.Template = templDir
 	}
 
 	_, err := git.Init(c, opts, dir)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ func Init(c *git.Client, args []string) error {
 
 	flags.BoolVar(&opts.Bare, "bare", false, "Create bare repository")
 	flags.BoolVar(&opts.Quiet, "quiet", false, "Only print errors or warnings")
+	flags.StringVar(&opts.Template, "template", "", "Specify the template directory that will be used")
 	q := flags.Bool("q", false, "Alias of --quiet")
 
 	flags.Parse(args)

--- a/git/config.go
+++ b/git/config.go
@@ -53,8 +53,11 @@ argChecker:
 		g.sections = append(g.sections, section)
 	}
 
-	sec.values[key] = value
-	fmt.Printf("%s", sec)
+        if sec != nil {
+	    sec.values[key] = value
+        } else {
+            fmt.Printf("Couldn't find section %v\n", name)
+        }
 }
 func (g GitConfig) GetConfig(name string) string {
 
@@ -107,6 +110,7 @@ func (s *GitConfigSection) ParseValues(valueslines string) {
 		}
 		varname := strings.TrimSpace(split[0])
 
+                //fmt.Printf("%v\n", varname)
 		s.values[varname] = strings.TrimSpace(strings.Join(split[1:], "="))
 
 	}
@@ -146,6 +150,7 @@ func ParseConfig(configFile io.Reader) GitConfig {
 	lastClosingBracket := 0
 
 	for idx, b := range rawdata {
+                //fmt.Printf("%v\n", rawdata)
 		if b == '[' && parsingSectionName == false {
 
 			parsingSectionName = true

--- a/git/init.go
+++ b/git/init.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -10,8 +11,7 @@ type InitOptions struct {
 	Quiet bool
 	Bare  bool
 
-	// Not implemented
-	TemplateDir File
+	Template string
 
 	// Not implemented
 	SeparateGitDir File
@@ -100,6 +100,15 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 		}
 		fmt.Printf("Initialized empty Git repository in %v/\n", dir)
 	}
+
+                if opts.Template != "" && !filepath.IsAbs(opts.Template) {
+                        wd, err := os.Getwd()
+                        if err != nil {
+                                return c, err
+                        }
+                        opts.Template = filepath.Join(wd, opts.Template)
+                }
+
 	// Now go into the directory and adjust workdir and gitdir so that
 	// tests are in the right place.
 	if err := os.Chdir(c.WorkDir.String()); err != nil {
@@ -111,5 +120,42 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 	}
 	c.WorkDir = WorkDir(wd)
 	c.GitDir = GitDir(wd + "/.git")
+
+	if opts.Template != "" {
+		err = filepath.Walk(opts.Template, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+                        path, err = filepath.Rel(opts.Template, path)
+                        if err != nil {
+                                return err
+                        }
+			if info.IsDir() {
+				os.MkdirAll(filepath.Join(c.GitDir.String(), path), 0770)
+			} else {
+				newFile, err := os.Create(filepath.Join(c.GitDir.String(), path))
+				if err != nil {
+					return err
+				}
+				defer newFile.Close()
+				f, err := os.Open(filepath.Join(opts.Template, path))
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				_, err = io.Copy(newFile, f)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return c, err
+		}
+	}
+
 	return c, nil
 }

--- a/main.go
+++ b/main.go
@@ -257,5 +257,6 @@ func main() {
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown git command %s.\n", subcommand)
+                os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	args := flag.Args()
 	if len(args) < 1 {
 		flag.Usage()
-		os.Exit(2)
+		os.Exit(1)
 	}
 	c, err := git.NewClient(*gitdir, *workdir)
 	subcommand = args[0]


### PR DESCRIPTION
Many of the official git tests make use of template parameter to initialize some of the data in the repository before running the test.