### PR TITLE
Exit code of 1 when there is an unknown git command

### DIFF
--- a/main.go
+++ b/main.go
@@ -257,5 +257,6 @@ func main() {
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown git command %s.\n", subcommand)
+                os.Exit(1)
 	}
 }


### PR DESCRIPTION
When you launch dgit with a subcommand unknown to it it exits with a code of 0 indicating a success. Instead, it should return 1 as the standard git command does.