### PR TITLE
Add logging infrastructure

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -33,7 +33,7 @@ func printCommit(c *git.Client, cmt git.CommitID) {
 		panic(err)
 	}
 	fmt.Printf("Author: %v\nDate:   %v\n\n", author, date.Format("Mon Jan 2 15:04:05 2006 -0700"))
-	log.Printf("commit %v\nAuthor: %v\nDate: %v\n\n", cmt.Id, author, author.When.Format("Mon Jan 2 15:04:05 2006 -0700"))
+	log.Printf("Commit %v\n", cmt)
 
 	msg, err := cmt.GetCommitMessage(c)
 	lines := strings.Split(strings.TrimSpace(msg.String()), "\n")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -33,7 +33,7 @@ func printCommit(c *git.Client, cmt git.CommitID) {
 		panic(err)
 	}
 	fmt.Printf("Author: %v\nDate:   %v\n\n", author, date.Format("Mon Jan 2 15:04:05 2006 -0700"))
-	log.Printf("commit %v\nAuthor: %v\nDate: %v\n\n", c.Id, c.Author, c.Author.When.Format("Mon Jan 2 15:04:05 2006 -0700"))
+	log.Printf("commit %v\nAuthor: %v\nDate: %v\n\n", cmt.Id, author, author.When.Format("Mon Jan 2 15:04:05 2006 -0700"))
 
 	msg, err := cmt.GetCommitMessage(c)
 	lines := strings.Split(strings.TrimSpace(msg.String()), "\n")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+        "log"
 	"os"
 	"strings"
 
@@ -32,7 +33,7 @@ func printCommit(c *git.Client, cmt git.CommitID) {
 		panic(err)
 	}
 	fmt.Printf("Author: %v\nDate:   %v\n\n", author, date.Format("Mon Jan 2 15:04:05 2006 -0700"))
-	//fmt.Printf("commit %v\nAuthor: %v\nDate: %v\n\n", c.Id, c.Author, c.Author.When.Format("Mon Jan 2 15:04:05 2006 -0700"))
+	log.Printf("commit %v\nAuthor: %v\nDate: %v\n\n", c.Id, c.Author, c.Author.When.Format("Mon Jan 2 15:04:05 2006 -0700"))
 
 	msg, err := cmt.GetCommitMessage(c)
 	lines := strings.Split(strings.TrimSpace(msg.String()), "\n")

--- a/git/config.go
+++ b/git/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+        "log"
 	"strings"
 )
 
@@ -110,7 +111,7 @@ func (s *GitConfigSection) ParseValues(valueslines string) {
 		}
 		varname := strings.TrimSpace(split[0])
 
-                //fmt.Printf("%v\n", varname)
+                log.Printf("%v\n", varname)
 		s.values[varname] = strings.TrimSpace(strings.Join(split[1:], "="))
 
 	}
@@ -150,7 +151,7 @@ func ParseConfig(configFile io.Reader) GitConfig {
 	lastClosingBracket := 0
 
 	for idx, b := range rawdata {
-                //fmt.Printf("%v\n", rawdata)
+                log.Printf("%v\n", rawdata)
 		if b == '[' && parsingSectionName == false {
 
 			parsingSectionName = true

--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+        "log"
 	"sort"
 )
 
@@ -74,7 +75,7 @@ func DiffFiles(c *Client, opt DiffFilesOptions, paths []File) ([]HashDiff, error
 		//		return nil, err
 		//	}
 		size := stat.Size()
-		//fmt.Printf("Mtime %v idxmtime %v Size: %v idxsize: %v\n", mtime, idx.Mtime, size, idx.Fsize)
+		log.Printf("Mtime %v idxmtime %v Size: %v idxsize: %v\n", mtime, idx.Mtime, size, idx.Fsize)
 		//if mtime != idx.Mtime || size != int64(idx.Fsize) {
 		hash, _, _ := HashFile("blob", f.String())
 

--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -70,10 +70,10 @@ func DiffFiles(c *Client, opt DiffFilesOptions, paths []File) ([]HashDiff, error
 		default:
 			fs.FileMode = ModeBlob
 		}
-		//mtime, err := f.MTime()
-		//if err != nil {
-		//		return nil, err
-		//	}
+		mtime, err := f.MTime()
+		if err != nil {
+				return nil, err
+		}
 		size := stat.Size()
 		log.Printf("Mtime %v idxmtime %v Size: %v idxsize: %v\n", mtime, idx.Mtime, size, idx.Fsize)
 		//if mtime != idx.Mtime || size != int64(idx.Fsize) {

--- a/git/writetree.go
+++ b/git/writetree.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
+        "log"
 	"strings"
 )
 
@@ -63,7 +64,7 @@ func writeTree(c *Client, prefix string, entries []*IndexEntry) (TreeID, error) 
 	lastname := ""
 	firstIdxForTree := -1
 
-	//	fmt.Printf("Prefix: %v\n", prefix)
+	log.Printf("Prefix: %v\n", prefix)
 	for idx, obj := range entries {
 		if !strings.HasPrefix(string(obj.PathName), prefix) {
 			continue

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"github.com/driusan/dgit/cmd"
 	"github.com/driusan/dgit/git"
+        "io/ioutil"
+        "log"
 	"os"
 )
 
@@ -23,6 +25,32 @@ func requiresGitDir(cmd string) bool {
 var subcommand, subcommandUsage string
 
 func main() {
+        // First thing, set up logging
+        log.SetFlags(log.Ldate|log.Ltime|log.Lshortfile)
+        traceLevel := os.Getenv("DGIT_TRACE")
+        if traceLevel == "" {
+           traceLevel = os.Getenv("GIT_TRACE")
+        } 
+      
+        // If no trace level specified then just dump any log output 
+        if traceLevel == "" {
+           log.SetOutput(ioutil.Discard)
+        } else if traceLevel != "1" && traceLevel != "2" {
+           logfile, err := os.Open(traceLevel)
+           if os.IsNotExist(err) {
+              logfile, err = os.Create(traceLevel)
+           }
+
+           if err != nil {
+              fmt.Printf("Could not open file %v for tracing: %v\n", traceLevel, err)
+              os.Exit(1)
+           }
+
+           log.SetOutput(logfile)
+        }
+
+        log.Printf("Dgit started\n")
+
 	workdir := flag.String("work-tree", "", "specify the working directory of git")
 	gitdir := flag.String("git-dir", "", "specify the repository of git")
 	dir := flag.String("C", "", "chdir before starting git")


### PR DESCRIPTION
The main function uses the DGIT_TRACE and GIT_TRACE environment variables to decide whether to enable tracing and where the tracing should go. I have converted some of the commented out fmt.Printf statements to use the log package instead.