### PR TITLE
Add diff cached option

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -9,9 +9,17 @@ import (
 func Diff(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff", flag.ExitOnError)
 	options := git.DiffOptions{}
-	flags.BoolVar(&options.Staged, "staged", false, "Display changes staged for commit")
+
+        var staged bool
+	flags.BoolVar(&staged, "staged", false, "Synonym for cached")
+        var cached bool
+	flags.BoolVar(&cached, "cached", false, "Display changes staged for commit")
 
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, true, flags, args)
+
+        if staged || cached {
+                options.Staged = true
+        }
 
 	files := make([]git.File, len(args), len(args))
 	for i := range args {


### PR DESCRIPTION
Added a separate --cached option for the diff subcommand and stated that the --staged is a synonym as stated in the official git documentation.