### PR TITLE
Add help subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ go:
 
 script:
     - diff -u <(echo -n) <(gofmt -d ./)
+    - go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ go:
   - "1.10.x"
   - master
 
-
+script:
+    - diff -u <(echo -n) <(gofmt -d ./)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,8 +12,9 @@ func Add(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("add", flag.ExitOnError)
 	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
+		flags.SetOutput(flag.CommandLine.Output())
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,17 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Add(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("add", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Add(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("add", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Add(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("add", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
 		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,7 +12,6 @@ func Add(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("add", flag.ExitOnError)
 	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
-		flags.SetOutput(flag.CommandLine.Output())
 		flag.Usage()
 		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,17 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Apply(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("apply", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -12,8 +12,9 @@ func Apply(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("apply", flag.ExitOnError)
 	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
+		flags.SetOutput(flag.CommandLine.Output())
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Apply(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("apply", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
 		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -12,7 +12,6 @@ func Apply(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("apply", flag.ExitOnError)
 	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
-		flags.SetOutput(flag.CommandLine.Output())
 		flag.Usage()
 		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Apply(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("apply", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -11,6 +12,7 @@ import (
 // and calls git.CatFiles
 func CatFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("cat-file", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.CatFileOptions{}
 
 	flags.BoolVar(&options.Pretty, "p", false, "Pretty print the object content")

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -12,7 +11,7 @@ import (
 // and calls git.CatFiles
 func CatFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("cat-file", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.CatFileOptions{}
 
 	flags.BoolVar(&options.Pretty, "p", false, "Pretty print the object content")

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -12,7 +12,7 @@ import (
 // and calls git.CatFiles
 func CatFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("cat-file", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.CatFileOptions{}
 
 	flags.BoolVar(&options.Pretty, "p", false, "Pretty print the object content")

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -11,7 +10,7 @@ import (
 // Implements the git checkout command line parsing.
 func Checkout(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.CheckoutOptions{}
 
 	quiet := flags.Bool("quiet", false, "Quiet. Suppress feedback messages.")

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -11,7 +11,7 @@ import (
 // Implements the git checkout command line parsing.
 func Checkout(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.CheckoutOptions{}
 
 	quiet := flags.Bool("quiet", false, "Quiet. Suppress feedback messages.")

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -10,6 +11,7 @@ import (
 // Implements the git checkout command line parsing.
 func Checkout(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.CheckoutOptions{}
 
 	quiet := flags.Bool("quiet", false, "Quiet. Suppress feedback messages.")

--- a/cmd/checkoutindex.go
+++ b/cmd/checkoutindex.go
@@ -11,7 +11,7 @@ import (
 // CheckoutIndexOptions and calls CheckoutIndex.
 func CheckoutIndexCmd(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout-index", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.CheckoutIndexOptions{}
 
 	index := flags.Bool("index", false, "Update stat information for checkout out entries in the index")

--- a/cmd/checkoutindex.go
+++ b/cmd/checkoutindex.go
@@ -11,7 +11,7 @@ import (
 // CheckoutIndexOptions and calls CheckoutIndex.
 func CheckoutIndexCmd(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout-index", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.CheckoutIndexOptions{}
 
 	index := flags.Bool("index", false, "Update stat information for checkout out entries in the index")

--- a/cmd/checkoutindex.go
+++ b/cmd/checkoutindex.go
@@ -11,6 +11,7 @@ import (
 // CheckoutIndexOptions and calls CheckoutIndex.
 func CheckoutIndexCmd(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout-index", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.CheckoutIndexOptions{}
 
 	index := flags.Bool("index", false, "Update stat information for checkout out entries in the index")

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"flag"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Diff(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.DiffOptions{}
 	flags.BoolVar(&options.Staged, "staged", false, "Display changes staged for commit")
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"flag"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Diff(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.DiffOptions{}
 	flags.BoolVar(&options.Staged, "staged", false, "Display changes staged for commit")
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -2,14 +2,14 @@ package cmd
 
 import (
 	"flag"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Diff(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.DiffOptions{}
 	flags.BoolVar(&options.Staged, "staged", false, "Display changes staged for commit")
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -11,16 +11,16 @@ func Diff(c *git.Client, args []string) error {
 	flags.SetOutput(flag.CommandLine.Output())
 	options := git.DiffOptions{}
 
-        var staged bool
+	var staged bool
 	flags.BoolVar(&staged, "staged", false, "Synonym for cached")
-        var cached bool
+	var cached bool
 	flags.BoolVar(&cached, "cached", false, "Display changes staged for commit")
 
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, true, flags, args)
 
-        if staged || cached {
-                options.Staged = true
-        }
+	if staged || cached {
+		options.Staged = true
+	}
 
 	files := make([]git.File, len(args), len(args))
 	for i := range args {

--- a/cmd/difffiles.go
+++ b/cmd/difffiles.go
@@ -2,14 +2,14 @@ package cmd
 
 import (
 	"flag"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-files", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.DiffFilesOptions{}
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, false, flags, args)
 	files := make([]git.File, len(args), len(args))

--- a/cmd/difffiles.go
+++ b/cmd/difffiles.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"flag"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-files", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.DiffFilesOptions{}
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, false, flags, args)
 	files := make([]git.File, len(args), len(args))

--- a/cmd/difffiles.go
+++ b/cmd/difffiles.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"flag"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-files", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.DiffFilesOptions{}
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, false, flags, args)
 	files := make([]git.File, len(args), len(args))

--- a/cmd/diffindex.go
+++ b/cmd/diffindex.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-index", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 
 	options := git.DiffIndexOptions{}
 	flags.BoolVar(&options.Cached, "cached", false, "Do not compare the filesystem, only the index")

--- a/cmd/diffindex.go
+++ b/cmd/diffindex.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-index", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 
 	options := git.DiffIndexOptions{}
 	flags.BoolVar(&options.Cached, "cached", false, "Do not compare the filesystem, only the index")

--- a/cmd/diffindex.go
+++ b/cmd/diffindex.go
@@ -3,14 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func DiffIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-index", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 
 	options := git.DiffIndexOptions{}
 	flags.BoolVar(&options.Cached, "cached", false, "Do not compare the filesystem, only the index")

--- a/cmd/difftree.go
+++ b/cmd/difftree.go
@@ -9,6 +9,7 @@ import (
 
 func DiffTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-tree", flag.ExitOnError)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.DiffTreeOptions{}
 
 	patch := flags.Bool("index", false, "Generate patch")

--- a/cmd/grep.go
+++ b/cmd/grep.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Grep(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("grep", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/grep.go
+++ b/cmd/grep.go
@@ -3,17 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Grep(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("grep", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/grep.go
+++ b/cmd/grep.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Grep(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("grep", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/indexpack.go
+++ b/cmd/indexpack.go
@@ -15,7 +15,7 @@ import (
 // and calls git.CatFiles
 func IndexPack(c *git.Client, args []string) (err error) {
 	flags := flag.NewFlagSet("index-pack", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
 		fmt.Printf("\n\nOptions:\n\n")

--- a/cmd/indexpack.go
+++ b/cmd/indexpack.go
@@ -15,10 +15,10 @@ import (
 // and calls git.CatFiles
 func IndexPack(c *git.Client, args []string) (err error) {
 	flags := flag.NewFlagSet("index-pack", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n\n")
 		flags.PrintDefaults()
 	}
 	options := git.IndexPackOptions{}

--- a/cmd/indexpack.go
+++ b/cmd/indexpack.go
@@ -15,9 +15,10 @@ import (
 // and calls git.CatFiles
 func IndexPack(c *git.Client, args []string) (err error) {
 	flags := flag.NewFlagSet("index-pack", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Fprintf(os.Stderr, "\nindex-pack options:\n\n")
+		fmt.Printf("\n\nOptions:\n\n")
 		flags.PrintDefaults()
 	}
 	options := git.IndexPackOptions{}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,10 +11,10 @@ import (
 
 func Init(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,6 +11,7 @@ import (
 
 func Init(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
 		flags.PrintDefaults()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,10 +11,10 @@ import (
 
 func Init(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -14,6 +14,7 @@ func Init(c *git.Client, args []string) error {
         flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-        "log"
+	"log"
 	"os"
 	"strings"
 

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -11,6 +12,7 @@ import (
 // and calls git.LsFiles
 func LsFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.LsFilesOptions{}
 
 	cached := flags.Bool("cached", true, "Show cached files in output (default)")

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -12,7 +11,7 @@ import (
 // and calls git.LsFiles
 func LsFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.LsFilesOptions{}
 
 	cached := flags.Bool("cached", true, "Show cached files in output (default)")

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -12,7 +12,7 @@ import (
 // and calls git.LsFiles
 func LsFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.LsFilesOptions{}
 
 	cached := flags.Bool("cached", true, "Show cached files in output (default)")

--- a/cmd/lstree.go
+++ b/cmd/lstree.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func LsTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 
 	opts := git.LsTreeOptions{}
 	flags.BoolVar(&opts.TreeOnly, "d", true, "Show only the named tree, not its children")

--- a/cmd/lstree.go
+++ b/cmd/lstree.go
@@ -3,14 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func LsTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 
 	opts := git.LsTreeOptions{}
 	flags.BoolVar(&opts.TreeOnly, "d", true, "Show only the named tree, not its children")

--- a/cmd/lstree.go
+++ b/cmd/lstree.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func LsTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 
 	opts := git.LsTreeOptions{}
 	flags.BoolVar(&opts.TreeOnly, "d", true, "Show only the named tree, not its children")

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -3,14 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Merge(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.MergeOptions{}
 
 	flags.BoolVar(&options.FastForwardOnly, "ff-only", false, "Only allow fast-forward merges")

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Merge(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.MergeOptions{}
 
 	flags.BoolVar(&options.FastForwardOnly, "ff-only", false, "Only allow fast-forward merges")

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Merge(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.MergeOptions{}
 
 	flags.BoolVar(&options.FastForwardOnly, "ff-only", false, "Only allow fast-forward merges")

--- a/cmd/mergebase.go
+++ b/cmd/mergebase.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -14,7 +14,7 @@ var NonAncestor error = errors.New("Commit not an ancestor")
 
 func MergeBase(c *git.Client, args []string) (git.CommitID, error) {
 	flags := flag.NewFlagSet("merge-base", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	var options git.MergeBaseOptions
 
 	flags.BoolVar(&options.Octopus, "octopus", false, "Compute the common ancestor of all supplied commits")

--- a/cmd/mergebase.go
+++ b/cmd/mergebase.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -13,6 +14,7 @@ var NonAncestor error = errors.New("Commit not an ancestor")
 
 func MergeBase(c *git.Client, args []string) (git.CommitID, error) {
 	flags := flag.NewFlagSet("merge-base", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	var options git.MergeBaseOptions
 
 	flags.BoolVar(&options.Octopus, "octopus", false, "Compute the common ancestor of all supplied commits")

--- a/cmd/mergebase.go
+++ b/cmd/mergebase.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -14,7 +13,7 @@ var NonAncestor error = errors.New("Commit not an ancestor")
 
 func MergeBase(c *git.Client, args []string) (git.CommitID, error) {
 	flags := flag.NewFlagSet("merge-base", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	var options git.MergeBaseOptions
 
 	flags.BoolVar(&options.Octopus, "octopus", false, "Compute the common ancestor of all supplied commits")

--- a/cmd/mergefile.go
+++ b/cmd/mergefile.go
@@ -10,7 +10,7 @@ import (
 
 func MergeFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge-file", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.MergeFileOptions{}
 
 	flags.Parse(args)

--- a/cmd/mergefile.go
+++ b/cmd/mergefile.go
@@ -10,7 +10,7 @@ import (
 
 func MergeFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge-file", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.MergeFileOptions{}
 
 	flags.Parse(args)

--- a/cmd/mergefile.go
+++ b/cmd/mergefile.go
@@ -10,6 +10,7 @@ import (
 
 func MergeFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge-file", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.MergeFileOptions{}
 
 	flags.Parse(args)

--- a/cmd/packobjects.go
+++ b/cmd/packobjects.go
@@ -12,7 +12,7 @@ import (
 
 func PackObjects(c *git.Client, input io.Reader, args []string) {
 	if len(args) != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: %s pack-objects basename\n", os.Args[0])
+		fmt.Fprintf(os.Stdout, "Usage: %s pack-objects basename\n", os.Args[0])
 		return
 	}
 	f, _ := os.Create(args[0] + ".pack")

--- a/cmd/readtree.go
+++ b/cmd/readtree.go
@@ -10,7 +10,7 @@ import (
 
 func ReadTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("read-tree", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
 		fmt.Fprintf(os.Stdout, "\nOptions:\n\n")

--- a/cmd/readtree.go
+++ b/cmd/readtree.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func ReadTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("read-tree", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Fprintf(os.Stdout, "\nOptions:\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\nOptions:\n\n")
 		flags.PrintDefaults()
 	}
 	options := git.ReadTreeOptions{}

--- a/cmd/readtree.go
+++ b/cmd/readtree.go
@@ -10,6 +10,12 @@ import (
 
 func ReadTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("read-tree", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(os.Stdout, "\nOptions:\n\n")
+		flags.PrintDefaults()
+	}
 	options := git.ReadTreeOptions{}
 	flags.BoolVar(&options.Merge, "m", false, "Perform a merge. Will not run if you have unmerged entries")
 	flags.BoolVar(&options.Reset, "reset", false, "Perform a merge. Will discard unmerged entries")
@@ -32,11 +38,6 @@ func ReadTree(c *git.Client, args []string) error {
 	flags.BoolVar(&options.Empty, "empty", false, "Instead of reading the treeish into the index, empty it")
 
 	flags.Parse(args)
-	flags.Usage = func() {
-		flag.Usage()
-		fmt.Fprintf(os.Stderr, "\nRead-Tree options:\n\n")
-		flags.PrintDefaults()
-	}
 	args = flags.Args()
 	options.DryRun = *dryrun || *n
 	switch len(args) {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -2,14 +2,18 @@ package cmd
 
 import (
 	"flag"
+        "fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Reset(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("reset", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Reset(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("reset", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -2,18 +2,18 @@ package cmd
 
 import (
 	"flag"
-        "fmt"
-        "os"
+	"fmt"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Reset(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("reset", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 	flags := flag.NewFlagSet("rev-list", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 
 	includeObjects := flags.Bool("objects", false, "include non-commit objects in output")
 	quiet := flags.Bool("quiet", false, "prevent printing of revisions")

--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -3,14 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 	flags := flag.NewFlagSet("rev-list", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 
 	includeObjects := flags.Bool("objects", false, "include non-commit objects in output")
 	quiet := flags.Bool("quiet", false, "prevent printing of revisions")

--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 	flags := flag.NewFlagSet("rev-list", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 
 	includeObjects := flags.Bool("objects", false, "include non-commit objects in output")
 	quiet := flags.Bool("quiet", false, "prevent printing of revisions")

--- a/cmd/revert.go
+++ b/cmd/revert.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Revert(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("revert", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/revert.go
+++ b/cmd/revert.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Revert(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("revert", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/revert.go
+++ b/cmd/revert.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Revert(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("revert", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Status(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,17 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
-        "os"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Status(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,14 +3,17 @@ package cmd
 import (
 	"flag"
 	"fmt"
+        "os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func Status(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("status", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/symbolicref.go
+++ b/cmd/symbolicref.go
@@ -10,9 +10,10 @@ import (
 
 func SymbolicRef(c *git.Client, args []string) (git.RefSpec, error) {
 	flags := flag.NewFlagSet("symbolic-ref", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Fprintf(os.Stderr, "\nsymbolic-ref options:\n\n")
+		fmt.Fprintf(os.Stdout, "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/symbolicref.go
+++ b/cmd/symbolicref.go
@@ -3,17 +3,16 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
 func SymbolicRef(c *git.Client, args []string) (git.RefSpec, error) {
 	flags := flag.NewFlagSet("symbolic-ref", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Fprintf(os.Stdout, "\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/symbolicref.go
+++ b/cmd/symbolicref.go
@@ -10,7 +10,7 @@ import (
 
 func SymbolicRef(c *git.Client, args []string) (git.RefSpec, error) {
 	flags := flag.NewFlagSet("symbolic-ref", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
 		fmt.Fprintf(os.Stdout, "\n\nOptions:\n")

--- a/cmd/unpackobjects.go
+++ b/cmd/unpackobjects.go
@@ -11,6 +11,7 @@ import (
 // and calls git.CatFiles
 func UnpackObjects(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("unpack-objects", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	options := git.UnpackObjectsOptions{}
 
 	flags.BoolVar(&options.DryRun, "n", false, "Do not really unpack the objects")

--- a/cmd/unpackobjects.go
+++ b/cmd/unpackobjects.go
@@ -11,7 +11,7 @@ import (
 // and calls git.CatFiles
 func UnpackObjects(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("unpack-objects", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	options := git.UnpackObjectsOptions{}
 
 	flags.BoolVar(&options.DryRun, "n", false, "Do not really unpack the objects")

--- a/cmd/unpackobjects.go
+++ b/cmd/unpackobjects.go
@@ -11,7 +11,7 @@ import (
 // and calls git.CatFiles
 func UnpackObjects(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("unpack-objects", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	options := git.UnpackObjectsOptions{}
 
 	flags.BoolVar(&options.DryRun, "n", false, "Do not really unpack the objects")

--- a/cmd/updateindex.go
+++ b/cmd/updateindex.go
@@ -43,10 +43,10 @@ func parseCacheInfo(input string) (git.CacheInfo, error) {
 
 func UpdateIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-index", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/updateindex.go
+++ b/cmd/updateindex.go
@@ -43,10 +43,10 @@ func parseCacheInfo(input string) (git.CacheInfo, error) {
 
 func UpdateIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-index", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/updateindex.go
+++ b/cmd/updateindex.go
@@ -43,8 +43,10 @@ func parseCacheInfo(input string) (git.CacheInfo, error) {
 
 func UpdateIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-index", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/updateref.go
+++ b/cmd/updateref.go
@@ -10,10 +10,10 @@ import (
 
 func UpdateRef(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-ref", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()
-		fmt.Printf("\n\nOptions:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/updateref.go
+++ b/cmd/updateref.go
@@ -10,8 +10,10 @@ import (
 
 func UpdateRef(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-ref", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
+                fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/updateref.go
+++ b/cmd/updateref.go
@@ -10,10 +10,10 @@ import (
 
 func UpdateRef(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("update-ref", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		flag.Usage()
-                fmt.Printf("\n\nOptions:\n")
+		fmt.Printf("\n\nOptions:\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/writetree.go
+++ b/cmd/writetree.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -13,11 +12,11 @@ import (
 // pointed to by c.
 func WriteTree(c *git.Client, args []string) string {
 	flags := flag.NewFlagSet("write-tree", flag.ExitOnError)
-	flags.SetOutput(os.Stdout)
+	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		//fmt.Fprintf(os.Stderr, "usage: %v write-tree [--missing-ok] [--prefix <prefix>/]\n\n", os.Args[0])
 		flag.Usage()
-		fmt.Fprintf(os.Stderr, "\nOptions:\n\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\nOptions:\n\n")
 		flags.PrintDefaults()
 	}
 

--- a/cmd/writetree.go
+++ b/cmd/writetree.go
@@ -13,6 +13,7 @@ import (
 // pointed to by c.
 func WriteTree(c *git.Client, args []string) string {
 	flags := flag.NewFlagSet("write-tree", flag.ExitOnError)
+        flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		//fmt.Fprintf(os.Stderr, "usage: %v write-tree [--missing-ok] [--prefix <prefix>/]\n\n", os.Args[0])
 		flag.Usage()

--- a/cmd/writetree.go
+++ b/cmd/writetree.go
@@ -13,7 +13,7 @@ import (
 // pointed to by c.
 func WriteTree(c *git.Client, args []string) string {
 	flags := flag.NewFlagSet("write-tree", flag.ExitOnError)
-        flags.SetOutput(os.Stdout)
+	flags.SetOutput(os.Stdout)
 	flags.Usage = func() {
 		//fmt.Fprintf(os.Stderr, "usage: %v write-tree [--missing-ok] [--prefix <prefix>/]\n\n", os.Args[0])
 		flag.Usage()

--- a/git/config.go
+++ b/git/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-        "log"
+	"log"
 	"strings"
 )
 
@@ -54,11 +54,11 @@ argChecker:
 		g.sections = append(g.sections, section)
 	}
 
-        if sec != nil {
-	    sec.values[key] = value
-        } else {
-            fmt.Printf("Couldn't find section %v\n", name)
-        }
+	if sec != nil {
+		sec.values[key] = value
+	} else {
+		fmt.Printf("Couldn't find section %v\n", name)
+	}
 }
 func (g GitConfig) GetConfig(name string) string {
 
@@ -111,7 +111,7 @@ func (s *GitConfigSection) ParseValues(valueslines string) {
 		}
 		varname := strings.TrimSpace(split[0])
 
-                log.Printf("%v\n", varname)
+		log.Printf("%v\n", varname)
 		s.values[varname] = strings.TrimSpace(strings.Join(split[1:], "="))
 
 	}
@@ -151,7 +151,7 @@ func ParseConfig(configFile io.Reader) GitConfig {
 	lastClosingBracket := 0
 
 	for idx, b := range rawdata {
-                log.Printf("%v\n", rawdata)
+		log.Printf("%v\n", rawdata)
 		if b == '[' && parsingSectionName == false {
 
 			parsingSectionName = true

--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -1,7 +1,7 @@
 package git
 
 import (
-        "log"
+	"log"
 	"sort"
 )
 
@@ -72,7 +72,7 @@ func DiffFiles(c *Client, opt DiffFilesOptions, paths []File) ([]HashDiff, error
 		}
 		mtime, err := f.MTime()
 		if err != nil {
-				return nil, err
+			return nil, err
 		}
 		size := stat.Size()
 		log.Printf("Mtime %v idxmtime %v Size: %v idxsize: %v\n", mtime, idx.Mtime, size, idx.Fsize)

--- a/git/status_test.go
+++ b/git/status_test.go
@@ -61,10 +61,10 @@ func compareStatus(c *Client, opts StatusOptions, expected expectedStatus) error
 // It also tests that the second commit can be done while
 // in a detached head mode.
 func TestStatus(t *testing.T) {
-        if os.Getenv("TRAVIS") == "true" {
-           fmt.Printf("Skipping known failure for Travis\n")
-           return
-        }
+	if os.Getenv("TRAVIS") == "true" {
+		fmt.Printf("Skipping known failure for Travis\n")
+		return
+	}
 
 	dir, err := ioutil.TempDir("", "gitstatus")
 	if err != nil {

--- a/git/writetree.go
+++ b/git/writetree.go
@@ -3,7 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
-        "log"
+	"log"
 	"strings"
 )
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
         "io/ioutil"
         "log"
 	"os"
+        "strings"
 )
 
 var InvalidArgument error = errors.New("Invalid argument to function")
@@ -51,10 +52,17 @@ func main() {
 
         log.Printf("Dgit started\n")
 
+        // Special case, just reverse the arguments to force regular --help handling
+        if len(os.Args) == 3 && os.Args[1] == "help" && !strings.HasPrefix(os.Args[2], "-") {
+                os.Args[1] = os.Args[2]
+                os.Args[2] = "--help"
+        }
+
 	workdir := flag.String("work-tree", "", "specify the working directory of git")
 	gitdir := flag.String("git-dir", "", "specify the repository of git")
 	dir := flag.String("C", "", "chdir before starting git")
 
+        flag.CommandLine.SetOutput(os.Stdout)
 	flag.Usage = func() {
 		if subcommand == "" {
 			subcommand = "subcommand"
@@ -62,8 +70,8 @@ func main() {
 		if subcommandUsage == "" {
 			subcommandUsage = fmt.Sprintf("%s [global options] %s [options]\n", os.Args[0], subcommand)
 		}
-		fmt.Fprintf(os.Stderr, "Usage: %s\n", subcommandUsage)
-		fmt.Fprintf(os.Stderr, "\nGlobal options:\n\n")
+		fmt.Fprintf(os.Stdout, "Usage: %s\n", subcommandUsage)
+		fmt.Fprintf(os.Stdout, "\nGlobal options:\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -283,6 +291,54 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(4)
 		}
+        case "help":
+                flag.Usage()
+
+                fmt.Fprintf(os.Stdout, "\nAvailable subcommands:\n")
+                fmt.Fprintf(os.Stdout, `
+   init
+   branch
+   checkout
+   checkout-index
+   cat-file
+   add          
+   commit         
+   commit-tree
+   write-tree
+   update-ref
+   log              
+   symbolic-ref
+   clone          
+   config
+   fetch          
+   reset
+   merge-file
+   merge
+   merge-base
+   rev-parse
+   rev-list
+   hash-object
+   status
+   ls-tree
+   push
+   pack-objects
+   send-pack
+   read-tree
+   diff
+   diff-files
+   diff-index
+   diff-tree
+   ls-files
+   index-pack
+   update-index
+   unpack-objects
+   grep
+   apply
+   revert
+   help
+`)
+
+                os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown git command %s.\n", subcommand)
                 os.Exit(1)


### PR DESCRIPTION
Let's add a help subcommand and clean up the help. Also, the standard git outputs usages on stdout, not stderr.