### PR TITLE
Add config --list capability

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,6 +43,8 @@ func Config(c *git.Client, args []string) {
 	case "--unset":
 		action = "unset"
 		args = args[1:]
+        case "--list":
+                action = "list"
 
 	// Type canonicalization isn't currently supported
 	//  and so we just strip them out and return the raw value
@@ -114,7 +116,12 @@ func Config(c *git.Client, args []string) {
 		defer outfile.Close()
 		config.WriteFile(outfile)
 		os.Exit(0)
-		return
+        case "list":
+                list := config.GetConfigList()
+                for _, entry := range list {
+                        fmt.Printf("%s\n", entry)
+                }
+                os.Exit(0)
 	}
 
 	panic("Unhandled action " + args[0])

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,16 +1,17 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/driusan/dgit/git"
 )
 
-func Config(c *git.Client, args []string) {
+func Config(c *git.Client, args []string) error {
 	if len(args) < 1 {
 		fmt.Fprintf(os.Stderr, "Usage: go-git config [<options>]\n")
-		return
+		os.Exit(1)
 	}
 	var fname string
 
@@ -27,12 +28,12 @@ func Config(c *git.Client, args []string) {
 
 	file, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
-		panic("Couldn't open config\n")
+		return err
 	}
 	config := git.ParseConfig(file)
 	err = file.Close()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	var action string
@@ -43,8 +44,8 @@ func Config(c *git.Client, args []string) {
 	case "--unset":
 		action = "unset"
 		args = args[1:]
-        case "--list":
-                action = "list"
+	case "--list":
+		action = "list"
 
 	// Type canonicalization isn't currently supported
 	//  and so we just strip them out and return the raw value
@@ -81,25 +82,25 @@ func Config(c *git.Client, args []string) {
 			os.Exit(code)
 		}
 		fmt.Printf("%s\n", val)
-		os.Exit(0)
+		return nil
 	case "set":
 		if len(args) < 2 {
 			fmt.Fprintf(os.Stderr, "Missing value to set config to\n")
-			return
+			os.Exit(1)
 		}
 
 		config.SetConfig(args[0], args[1])
 		err = os.Remove(fname)
 		if err != nil {
-			panic("Couldn't rewrite config\n")
+			return err
 		}
 		outfile, err := os.Create(fname)
 		if err != nil {
-			panic("Couldn't open config\n")
+			return err
 		}
 		defer outfile.Close()
 		config.WriteFile(outfile)
-		return
+		return nil
 	case "unset":
 		code := config.Unset(args[0])
 		if code != 0 {
@@ -107,22 +108,22 @@ func Config(c *git.Client, args []string) {
 		}
 		err = os.Remove(fname)
 		if err != nil {
-			panic("Couldn't rewrite config\n")
+			return err
 		}
 		outfile, err := os.Create(fname)
 		if err != nil {
-			panic("Couldn't open config\n")
+			return err
 		}
 		defer outfile.Close()
 		config.WriteFile(outfile)
-		os.Exit(0)
-        case "list":
-                list := config.GetConfigList()
-                for _, entry := range list {
-                        fmt.Printf("%s\n", entry)
-                }
-                os.Exit(0)
+		return nil
+	case "list":
+		list := config.GetConfigList()
+		for _, entry := range list {
+			fmt.Printf("%s\n", entry)
+		}
+		return nil
 	}
 
-	panic("Unhandled action " + args[0])
+	return errors.New("Unhandled action " + args[0])
 }

--- a/git/config.go
+++ b/git/config.go
@@ -133,20 +133,20 @@ func (g *GitConfig) GetConfig(name string) (string, int) {
 }
 
 func (g *GitConfig) GetConfigList() []string {
-        list := []string {}
+	list := []string{}
 
-        for _, section := range g.sections {
-                for key, value := range section.values {
-                        if section.subsection != "" {
-                              list = append(list, section.name + "." + section.subsection + "." + key + "=" + value)
-                        } else {
-                              list = append(list, section.name + "." + key + "=" + value)
-                        }
-                }
-        }
+	for _, section := range g.sections {
+		for key, value := range section.values {
+			if section.subsection != "" {
+				list = append(list, section.name+"."+section.subsection+"."+key+"="+value)
+			} else {
+				list = append(list, section.name+"."+key+"="+value)
+			}
+		}
+	}
 
-        return list
-}  
+	return list
+}
 
 func (g GitConfig) WriteFile(w io.Writer) {
 	for _, section := range g.sections {

--- a/git/config.go
+++ b/git/config.go
@@ -132,6 +132,22 @@ func (g *GitConfig) GetConfig(name string) (string, int) {
 	return "", 1
 }
 
+func (g *GitConfig) GetConfigList() []string {
+        list := []string {}
+
+        for _, section := range g.sections {
+                for key, value := range section.values {
+                        if section.subsection != "" {
+                              list = append(list, section.name + "." + section.subsection + "." + key + "=" + value)
+                        } else {
+                              list = append(list, section.name + "." + key + "=" + value)
+                        }
+                }
+        }
+
+        return list
+}  
+
 func (g GitConfig) WriteFile(w io.Writer) {
 	for _, section := range g.sections {
 		if section.subsection == "" {

--- a/main.go
+++ b/main.go
@@ -175,7 +175,10 @@ func main() {
 
 		}
 	case "config":
-		cmd.Config(c, args)
+		if err := cmd.Config(c, args); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(2)
+		}
 	case "fetch":
 		cmd.Fetch(c, args)
 	case "reset":


### PR DESCRIPTION
This adds the plain --list option to the git config command.

When "-l" is implemented there are other sub-switches that should be added such as showing only the keys.