### PR TITLE
Fix usages, hangs and misinterpreted commands

### DIFF
--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -12,6 +12,11 @@ import (
 func CatFile(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("cat-file", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.CatFileOptions{}
 
 	flags.BoolVar(&options.Pretty, "p", false, "Pretty print the object content")

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -11,6 +11,11 @@ import (
 func Checkout(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.CheckoutOptions{}
 
 	quiet := flags.Bool("quiet", false, "Quiet. Suppress feedback messages.")

--- a/cmd/checkoutindex.go
+++ b/cmd/checkoutindex.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/driusan/dgit/git"
@@ -12,6 +13,11 @@ import (
 func CheckoutIndexCmd(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("checkout-index", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.CheckoutIndexOptions{}
 
 	index := flags.Bool("index", false, "Update stat information for checkout out entries in the index")

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -68,6 +69,9 @@ func Commit(c *git.Client, args []string) (string, error) {
 			opts.CleanupMode = args[idx+1]
 		case "-a", "--all":
 			opts.All = true
+		case "--help":
+			flag.PrintDefaults()
+			os.Exit(0)
 		}
 	}
 	if !opts.NoEdit {

--- a/cmd/committree.go
+++ b/cmd/committree.go
@@ -10,7 +10,7 @@ import (
 )
 
 func CommitTree(c *git.Client, args []string) (git.CommitID, error) {
-	if len(args) == 0 {
+	if len(args) == 0 || (len(args) == 1 && args[0] == "--help") {
 		// This doesn't use the flag package, because -m or -p can be specified multiple times
 		return git.CommitID{}, fmt.Errorf("Usage: %s commit-tree [(-p <sha1>)...] [-m <message>] [-F <file>]  <sha1>", os.Args[0])
 	}
@@ -51,7 +51,6 @@ func CommitTree(c *git.Client, args []string) (git.CommitID, error) {
 		case "-F":
 			messageFile = args[idx+1]
 			skipNext = true
-
 		}
 	}
 	if messageString == "" && messageFile == "" {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/driusan/dgit/git"
 )
@@ -9,6 +10,11 @@ import (
 func Diff(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.DiffOptions{}
 
 	var staged bool

--- a/cmd/difffiles.go
+++ b/cmd/difffiles.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/driusan/dgit/git"
 )
@@ -9,6 +10,11 @@ import (
 func DiffFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-files", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.DiffFilesOptions{}
 	args, err := parseCommonDiffFlags(c, &options.DiffCommonOptions, false, flags, args)
 	files := make([]git.File, len(args), len(args))

--- a/cmd/diffindex.go
+++ b/cmd/diffindex.go
@@ -10,6 +10,11 @@ import (
 func DiffIndex(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-index", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 
 	options := git.DiffIndexOptions{}
 	flags.BoolVar(&options.Cached, "cached", false, "Do not compare the filesystem, only the index")

--- a/cmd/difftree.go
+++ b/cmd/difftree.go
@@ -10,6 +10,11 @@ import (
 func DiffTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("diff-tree", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.DiffTreeOptions{}
 
 	patch := flags.Bool("index", false, "Generate patch")

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -12,6 +12,11 @@ import (
 func LsFiles(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.LsFilesOptions{}
 
 	cached := flags.Bool("cached", true, "Show cached files in output (default)")

--- a/cmd/lstree.go
+++ b/cmd/lstree.go
@@ -10,6 +10,11 @@ import (
 func LsTree(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 
 	opts := git.LsTreeOptions{}
 	flags.BoolVar(&opts.TreeOnly, "d", true, "Show only the named tree, not its children")

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -10,6 +10,11 @@ import (
 func Merge(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("merge", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.MergeOptions{}
 
 	flags.BoolVar(&options.FastForwardOnly, "ff-only", false, "Only allow fast-forward merges")

--- a/cmd/mergebase.go
+++ b/cmd/mergebase.go
@@ -14,6 +14,11 @@ var NonAncestor error = errors.New("Commit not an ancestor")
 func MergeBase(c *git.Client, args []string) (git.CommitID, error) {
 	flags := flag.NewFlagSet("merge-base", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	var options git.MergeBaseOptions
 
 	flags.BoolVar(&options.Octopus, "octopus", false, "Compute the common ancestor of all supplied commits")

--- a/cmd/packobjects.go
+++ b/cmd/packobjects.go
@@ -11,7 +11,7 @@ import (
 )
 
 func PackObjects(c *git.Client, input io.Reader, args []string) {
-	if len(args) != 1 {
+	if len(args) != 1 || (len(args) == 1 && args[0] == "--help") {
 		fmt.Fprintf(os.Stdout, "Usage: %s pack-objects basename\n", os.Args[0])
 		return
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Push(c *git.Client, args []string) {
-	if len(args) < 1 {
+	if len(args) < 1 || (len(args) == 1 && args[0] == "--help") {
 		fmt.Fprintf(os.Stderr, "Missing repository to fetch")
 		return
 	}

--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -10,6 +10,11 @@ import (
 func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 	flags := flag.NewFlagSet("rev-list", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 
 	includeObjects := flags.Bool("objects", false, "include non-commit objects in output")
 	quiet := flags.Bool("quiet", false, "prevent printing of revisions")

--- a/cmd/rev-parse.go
+++ b/cmd/rev-parse.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+        "fmt"
+
 	"github.com/driusan/dgit/git"
 )
 
 func RevParse(c *git.Client, args []string) (commits []git.ParsedRevision, err2 error) {
+	if len(args) == 1 && args[0] == "--help" {
+		fmt.Printf("Usage: dgit parse-rev <commid>\n")
+	}
 	return git.RevParse(c, git.RevParseOptions{}, args)
 }

--- a/cmd/unpackobjects.go
+++ b/cmd/unpackobjects.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/driusan/dgit/git"
@@ -12,6 +13,11 @@ import (
 func UnpackObjects(c *git.Client, args []string) error {
 	flags := flag.NewFlagSet("unpack-objects", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
 	options := git.UnpackObjectsOptions{}
 
 	flags.BoolVar(&options.DryRun, "n", false, "Do not really unpack the objects")

--- a/main.go
+++ b/main.go
@@ -69,10 +69,8 @@ func main() {
 		if subcommand == "" {
 			subcommand = "subcommand"
 		}
-		if subcommandUsage == "" {
-			subcommandUsage = fmt.Sprintf("%s [global options] %s [options]\n", os.Args[0], subcommand)
-		}
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s\n", subcommandUsage)
+		subcommandUsage = fmt.Sprintf("%s [global options] %s [options] %s", os.Args[0], subcommand, subcommandUsage)
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s\n\n", subcommandUsage)
 		fmt.Fprintf(flag.CommandLine.Output(), "\nGlobal options:\n\n")
 		flag.PrintDefaults()
 	}
@@ -187,6 +185,7 @@ func main() {
 			os.Exit(2)
 		}
 	case "merge-file":
+                subcommandUsage = "<current-file> <base-file> <other-file>"
 		if err := cmd.MergeFile(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(2)
@@ -223,6 +222,7 @@ func main() {
 		}
 
 	case "rev-list":
+                subcommandUsage = "<commit>..."
 		cmd.RevList(c, args)
 	case "hash-object":
 		cmd.HashObject(c, args)
@@ -232,6 +232,7 @@ func main() {
 			os.Exit(4)
 		}
 	case "ls-tree":
+                subcommandUsage = "[<path>...]"
 		if err := cmd.LsTree(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(4)
@@ -248,6 +249,7 @@ func main() {
 			os.Exit(4)
 		}
 	case "diff":
+                subcommandUsage = "[<path>...]"
 		if err := cmd.Diff(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(4)
@@ -268,6 +270,7 @@ func main() {
 			os.Exit(4)
 		}
 	case "ls-files":
+                subcommandUsage = "[<file>...]"
 		if err := cmd.LsFiles(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(4)
@@ -288,11 +291,13 @@ func main() {
 			os.Exit(4)
 		}
 	case "grep":
+                subcommandUsage = "[<pathspec>...]"
 		if err := cmd.Grep(c, args); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(4)
 		}
 	case "apply":
+                subcommandUsage = "[<patch>...]"
 		if err := cmd.Apply(c, args); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(4)


### PR DESCRIPTION
The usages were not quite right for certain subcommands and others that don't use the flags package were hanging and misinterpreting the "--help" flag being passed to them from the help subcommand. This pull request should clean them all up.