### PR TITLE
Initial update-index refresh implementation

### DIFF
--- a/git/index.go
+++ b/git/index.go
@@ -70,6 +70,36 @@ type FixedIndexEntry struct {
 	Flags uint16 // 74
 }
 
+// Refreshes the stat information for this entry using the file
+// file
+func (i *FixedIndexEntry) RefreshStat(f File) error {
+	// FIXME: Add other stat info here too, but these are the
+	// most important ones and the onlye ones that the os package
+	// exposes in a cross-platform way.
+	stat, err := f.Lstat()
+	if err != nil {
+		return err
+	}
+	fmtime, err := f.MTime()
+	if err != nil {
+		return err
+	}
+	i.Mtime = fmtime
+	i.Fsize = uint32(stat.Size())
+	return nil
+}
+
+// Refreshes the stat information for an index entry by comparing
+// it against the path in the index.
+func (ie *IndexEntry) RefreshStat(c *Client) error {
+	f, err := ie.PathName.FilePath(c)
+	if err != nil {
+		return err
+	}
+	return ie.FixedIndexEntry.RefreshStat(f)
+}
+
+
 // Reads the index file from the GitDir and returns a Index object.
 // If the index file does not exist, it will return a new empty Index.
 func (d GitDir) ReadIndex() (*Index, error) {

--- a/git/index.go
+++ b/git/index.go
@@ -99,7 +99,6 @@ func (ie *IndexEntry) RefreshStat(c *Client) error {
 	return ie.FixedIndexEntry.RefreshStat(f)
 }
 
-
 // Reads the index file from the GitDir and returns a Index object.
 // If the index file does not exist, it will return a new empty Index.
 func (d GitDir) ReadIndex() (*Index, error) {

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -70,6 +70,9 @@ func UpdateIndex(c *Client, idx *Index, opts UpdateIndexOptions, files []File) (
 	if opts.IndexInfo != nil {
 		return UpdateIndexFromReader(c, opts, opts.IndexInfo)
 	}
+	if opts.Refresh {
+		return UpdateIndexRefresh(c, idx, opts)
+	}
 	for _, file := range files {
 		ipath, err := file.IndexPath(c)
 		if err != nil {
@@ -152,6 +155,15 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
+	}
+	return idx, nil
+}
+
+func UpdateIndexRefresh(c *Client, idx *Index, opts UpdateIndexOptions) (*Index, error) {
+	for _, entry := range idx.Objects {
+		if err := entry.RefreshStat(c); err != nil {
+			return nil, err
+		}
 	}
 	return idx, nil
 }


### PR DESCRIPTION
@sirnewton01 I'm sending this as a PR just in case you're going through test cases so you don't duplicate work. This adds an initial implementation of update-index --refresh.

The test case from git's t0000-basic.sh is still failing, so I'm not merging it yet, but I suspect it might be failing because the tests are run sequentially and the previous "validate git-diff-files output against a known state" is failing and needs to work first. (Ie it might be finding a diff because there really is a diff even after refreshing the stat info.)

It also needs dgit test cases written in Go.