### PR TITLE
Implement update-index --refresh and make diff-files output match real git client

### DIFF
--- a/cmd/updateindex.go
+++ b/cmd/updateindex.go
@@ -166,8 +166,8 @@ func UpdateIndex(c *git.Client, args []string) error {
 	if err != nil {
 		return err
 	}
-	newidx, err := git.UpdateIndex(c, idx, opts, files)
 
+	newidx, err := git.UpdateIndex(c, idx, opts, files)
 	if err != nil {
 		return err
 	}

--- a/git/add.go
+++ b/git/add.go
@@ -62,6 +62,7 @@ func Add(c *Client, opts AddOptions, files []File) (*Index, error) {
 		}
 		return c.GitDir.ReadIndex()
 	}
+
 	if len(files) == 0 {
 		if !opts.All && !opts.Update {
 			return nil, fmt.Errorf("Nothing to add. Did you mean \"git add .\"")

--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -63,7 +63,6 @@ func DiffFiles(c *Client, opt DiffFilesOptions, paths []File) ([]HashDiff, error
 			// Since we're diffing files in the index (which only holds files)
 			// against a directory, it means that the file was deleted and
 			// replaced by a directory.
-			//fs.FileMode = ModeTree
 			val = append(val, HashDiff{idx.PathName, idxtree, fs, uint(idx.Fsize), 0})
 			continue
 		case !stat.Mode().IsRegular():

--- a/git/file_ctime_darwin.go
+++ b/git/file_ctime_darwin.go
@@ -10,6 +10,6 @@ func (f File) CTime() (uint32, uint32) {
 		return 0, 0
 	}
 	rawstat := stat.Sys().(*syscall.Stat_t)
-	tspec := rawstat.Ctim
+	tspec := rawstat.Ctimespec
 	return uint32(tspec.Sec), uint32(tspec.Nsec)
 }

--- a/git/file_ctime_dragonfly.go
+++ b/git/file_ctime_dragonfly.go
@@ -1,0 +1,15 @@
+package git
+
+import (
+	"syscall"
+)
+
+func (f File) CTime() (uint32, uint32) {
+	stat, err := f.Lstat()
+	if err != nil {
+		return 0, 0
+	}
+	rawstat := stat.Sys().(*syscall.Stat_t)
+	tspec := rawstat.Ctim
+	return uint32(tspec.Sec), uint32(tspec.Nsec)
+}

--- a/git/file_ctime_other.go
+++ b/git/file_ctime_other.go
@@ -1,4 +1,6 @@
 // +build !dragonfly
+// +build !darwin
+// +build !linux
 
 package git
 

--- a/git/file_ctime_other.go
+++ b/git/file_ctime_other.go
@@ -1,0 +1,13 @@
+// +build !dragonfly
+
+package git
+
+// Ctime returns the CTime and CTimeNano parts of a time struct
+// for the ctime of this file. On systems where either there's no
+// ctime, we don't know how to get it, or or we haven't implemented
+// it yet, this will return 0s instead of an error so that there will
+// be sane behaviour on places that use it (such as index updating)
+// that we shouldn't be propagating a non-critical error.
+func (f File) CTime() (uint32, uint32) {
+	return 0, 0
+}

--- a/git/file_ctime_unix.go
+++ b/git/file_ctime_unix.go
@@ -1,0 +1,17 @@
+// +build dragonfly linux
+
+package git
+
+import (
+	"syscall"
+)
+
+func (f File) CTime() (uint32, uint32) {
+	stat, err := f.Lstat()
+	if err != nil {
+		return 0, 0
+	}
+	rawstat := stat.Sys().(*syscall.Stat_t)
+	tspec := rawstat.Ctim
+	return uint32(tspec.Sec), uint32(tspec.Nsec)
+}

--- a/git/index.go
+++ b/git/index.go
@@ -70,6 +70,36 @@ type FixedIndexEntry struct {
 	Flags uint16 // 74
 }
 
+// Refreshes the stat information for this entry using the file
+// file
+func (i *FixedIndexEntry) RefreshStat(f File) error {
+	// FIXME: Add other stat info here too, but these are the
+	// most important ones and the onlye ones that the os package
+	// exposes in a cross-platform way.
+	stat, err := f.Lstat()
+	if err != nil {
+		return err
+	}
+	fmtime, err := f.MTime()
+	if err != nil {
+		return err
+	}
+	i.Mtime = fmtime
+	i.Fsize = uint32(stat.Size())
+	return nil
+}
+
+// Refreshes the stat information for an index entry by comparing
+// it against the path in the index.
+func (ie *IndexEntry) RefreshStat(c *Client) error {
+	f, err := ie.PathName.FilePath(c)
+	if err != nil {
+		return err
+	}
+	return ie.FixedIndexEntry.RefreshStat(f)
+}
+
+
 // Reads the index file from the GitDir and returns a Index object.
 // If the index file does not exist, it will return a new empty Index.
 func (d GitDir) ReadIndex() (*Index, error) {

--- a/git/index.go
+++ b/git/index.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"sort"
 )
@@ -73,6 +74,7 @@ type FixedIndexEntry struct {
 // Refreshes the stat information for this entry using the file
 // file
 func (i *FixedIndexEntry) RefreshStat(f File) error {
+	log.Printf("Refreshing stat info for %v\n", f)
 	// FIXME: Add other stat info here too, but these are the
 	// most important ones and the onlye ones that the os package
 	// exposes in a cross-platform way.
@@ -86,6 +88,8 @@ func (i *FixedIndexEntry) RefreshStat(f File) error {
 	}
 	i.Mtime = fmtime
 	i.Fsize = uint32(stat.Size())
+	i.Ctime, i.Ctimenano = f.CTime()
+
 	return nil
 }
 
@@ -140,6 +144,7 @@ func (d GitDir) ReadIndex() (*Index, error) {
 }
 
 func ReadIndexEntry(file *os.File) (*IndexEntry, error) {
+	log.Println("Reading from index entry from", file.Name())
 	var f FixedIndexEntry
 	var name []byte
 	binary.Read(file, binary.BigEndian, &f)

--- a/git/index.go
+++ b/git/index.go
@@ -233,6 +233,13 @@ func (g *Index) AddStage(c *Client, path IndexPath, mode EntryMode, s Sha1, stag
 			entry.Mtime = mtime
 			entry.Fsize = size
 
+			file, _ := path.FilePath(c)
+			if file.Exists() {
+				// FIXME: mtime/fsize/etc and ctime should either all be
+				// from the filesystem, or all come from the caller
+				entry.Ctime, entry.Ctimenano = file.CTime()
+			}
+
 			// We found and updated the entry, no need to continue
 			return nil
 		}

--- a/git/index.go
+++ b/git/index.go
@@ -99,7 +99,6 @@ func (ie *IndexEntry) RefreshStat(c *Client) error {
 	return ie.FixedIndexEntry.RefreshStat(f)
 }
 
-
 // Reads the index file from the GitDir and returns a Index object.
 // If the index file does not exist, it will return a new empty Index.
 func (d GitDir) ReadIndex() (*Index, error) {

--- a/git/revert.go
+++ b/git/revert.go
@@ -84,7 +84,7 @@ func Revert(c *Client, opts RevertOptions, commits []Commitish) error {
 	if err := GeneratePatch(c, DiffCommonOptions{Patch: true}, diff, patch); err != nil {
 		return err
 	}
-	if err := Apply(c, ApplyOptions{ThreeWay: true, Reverse: true}, []File{File(patch.Name())}); err != nil {
+	if err := Apply(c, ApplyOptions{ThreeWay: true, Reverse: true, Index: true}, []File{File(patch.Name())}); err != nil {
 		return err
 	}
 	return nil

--- a/git/revert_test.go
+++ b/git/revert_test.go
@@ -67,7 +67,7 @@ func TestRevert(t *testing.T) {
 
 	// Revert the last commit, so that we know there won't be conflicts..
 	if err := Revert(c, RevertOptions{Edit: false}, []Commitish{last}); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	content, err := ioutil.ReadFile("foo.txt")

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -70,6 +70,9 @@ func UpdateIndex(c *Client, idx *Index, opts UpdateIndexOptions, files []File) (
 	if opts.IndexInfo != nil {
 		return UpdateIndexFromReader(c, opts, opts.IndexInfo)
 	}
+	if opts.Refresh {
+		return UpdateIndexRefresh(c, idx, opts)
+	}
 	for _, file := range files {
 		ipath, err := file.IndexPath(c)
 		if err != nil {
@@ -152,6 +155,15 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err
+	}
+	return idx, nil
+}
+
+func UpdateIndexRefresh(c *Client, idx *Index, opts UpdateIndexOptions) (*Index, error) {
+	for _, entry := range idx.Objects {
+		if err := entry.RefreshStat(c); err != nil {
+			return nil, err
+		}
 	}
 	return idx, nil
 }


### PR DESCRIPTION
This makes the dgit diff-files command more accurately represent that of git diff-files, where only lstat information appears to be used to look for differences, not the hash of the file content.

Unfortunately, this requires comparing the ctime information, or tests will fail, and Go only easily exposes the mtime in a cross-platform way. I've added a file.CTime() function but only implemented it for DragonFly so far in this PR.

On other systems, we fall back on the old (incompatible, but reasonable to me) behaviour of hashing the file to see if there's differences rather than just `stat`ing them.