### PR TITLE
Fix ls-files so that it doesn't show sibling files

### DIFF
--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -10,7 +10,7 @@ import (
 // Parses the arguments from git-ls-files as if they were passed on the commandline
 // and calls git.LsFiles
 func LsFiles(c *git.Client, args []string) error {
-	flags := flag.NewFlagSet("ls-files", flag.ExitOnError)
+	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -10,7 +10,7 @@ import (
 // Parses the arguments from git-ls-files as if they were passed on the commandline
 // and calls git.LsFiles
 func LsFiles(c *git.Client, args []string) error {
-	flags := flag.NewFlagSet("ls-tree", flag.ExitOnError)
+	flags := flag.NewFlagSet("ls-files", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
 		flag.Usage()

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -137,7 +137,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				if err != nil {
 					return nil, err
 				}
-				if strings.HasPrefix(fAbs, eAbs) {
+				if fAbs == eAbs || strings.HasPrefix(fAbs, eAbs+"/") {
 					skip = false
 					break
 				}
@@ -213,7 +213,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 					if err != nil {
 						return nil, err
 					}
-					if strings.HasPrefix(fAbs, eAbs) {
+					if fAbs == eAbs || strings.HasPrefix(fAbs, eAbs+"/") {
 						skip = false
 						break
 					}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -137,7 +137,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				if err != nil {
 					return nil, err
 				}
-				if strings.HasPrefix(fAbs, eAbs + "/") {
+				if strings.HasPrefix(fAbs, eAbs) {
 					skip = false
 					break
 				}
@@ -213,7 +213,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 					if err != nil {
 						return nil, err
 					}
-					if strings.HasPrefix(fAbs, eAbs + "/") {
+					if strings.HasPrefix(fAbs, eAbs) {
 						skip = false
 						break
 					}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -137,7 +137,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				if err != nil {
 					return nil, err
 				}
-				if strings.HasPrefix(fAbs, eAbs) {
+				if strings.HasPrefix(fAbs, eAbs + "/") {
 					skip = false
 					break
 				}
@@ -213,7 +213,7 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 					if err != nil {
 						return nil, err
 					}
-					if strings.HasPrefix(fAbs, eAbs) {
+					if strings.HasPrefix(fAbs, eAbs + "/") {
 						skip = false
 						break
 					}


### PR DESCRIPTION
The official git test suite was catching a case where when you do a "git ls-files foo" and there is a sibling file called "foobar". It was listing "foobar" even though it is not a child of foo. Resolving this fixes one half of the problem with the t0000-basic.sh 'update-index D/F conflict' test case.