### PR TITLE
Hook replace option in update-index command

### DIFF
--- a/git/index.go
+++ b/git/index.go
@@ -255,8 +255,7 @@ func (g *Index) AddStage(c *Client, path IndexPath, mode EntryMode, s Sha1, stag
 	// Update the existing stage, if it exists.
 	for _, entry := range g.Objects {
 		if entry.PathName == path && entry.Stage() == stage {
-			err := replaceEntriesCheck()
-			if err != nil {
+			if err := replaceEntriesCheck(); err != nil {
 				return err
 			}
 
@@ -302,8 +301,7 @@ func (g *Index) AddStage(c *Client, path IndexPath, mode EntryMode, s Sha1, stag
 		flags |= (uint16(len(path)) & 0x0FFF)
 	}
 
-	err := replaceEntriesCheck()
-	if err != nil {
+	if err := replaceEntriesCheck(); err != nil {
 		return err
 	}
 

--- a/git/index.go
+++ b/git/index.go
@@ -227,37 +227,42 @@ func (g *Index) AddStage(c *Client, path IndexPath, mode EntryMode, s Sha1, stag
 		defer g.RemoveUnmergedStages(c, path)
 	}
 
-        replaceEntriesCheck := func() error {
-                        // If replace is true then we search for any entries that
-                        //  should be replaced with this one. It could be that there
-                        //  are entries with the same SHA-1 hash or there are children
-                        //  that are orphaned because of the change from a directory to
-                        //  a file.
-                        newObjects := make([]*IndexEntry, 0, len(g.Objects))
-                        for _, e := range g.Objects {
-                                if strings.HasPrefix(string(e.PathName), string(path)+"/") {
-                                        if !replaceEntry {
-                                                return fmt.Errorf("There is an existing file %s under %s, should it be replaced?")
-                                        }
-                                        continue
-                                }
+	replaceEntriesCheck := func() error {
+		// If replace is true then we search for any entries that
+		//  should be replaced with this one. It could be that there
+		//  are entries with the same SHA-1 hash or there are children
+		//  that are orphaned because of the change from a directory to
+		//  a file.
+		newObjects := make([]*IndexEntry, 0, len(g.Objects))
+		for _, e := range g.Objects {
+			if strings.HasPrefix(string(e.PathName), string(path)+"/") {
+				if !replaceEntry {
+					return fmt.Errorf("There is an existing file %s under %s, should it be replaced?", e.PathName, path)
+				}
+				continue
+			} else if strings.HasPrefix(string(path), string(e.PathName)+"/") {
+				if !replaceEntry {
+					return fmt.Errorf("There is a parent file %s above %s, should it be replaced?", e.PathName, path)
+				}
+				continue
+			}
 
-                                newObjects = append(newObjects, e)
-                        }
-                        if replaceEntry {
-                                g.Objects = newObjects
-                        }
+			newObjects = append(newObjects, e)
+		}
+		if replaceEntry {
+			g.Objects = newObjects
+		}
 
-                        return nil
-       }
+		return nil
+	}
 
 	// Update the existing stage, if it exists.
 	for _, entry := range g.Objects {
 		if entry.PathName == path && entry.Stage() == stage {
-                        err := replaceEntriesCheck()
-                        if err != nil {
-                                return err
-                        }
+			err := replaceEntriesCheck()
+			if err != nil {
+				return err
+			}
 
 			entry.Sha1 = s
 			entry.Mtime = mtime
@@ -301,10 +306,10 @@ func (g *Index) AddStage(c *Client, path IndexPath, mode EntryMode, s Sha1, stag
 		flags |= (uint16(len(path)) & 0x0FFF)
 	}
 
-        err := replaceEntriesCheck()
-        if err != nil {
-                return err
-        }
+	err := replaceEntriesCheck()
+	if err != nil {
+		return err
+	}
 
 	g.Objects = append(g.Objects, &IndexEntry{
 		FixedIndexEntry{

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -113,14 +113,14 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// If both stage2 and stage3 are the same, the work has been done in
 		// both branches, so collapse to stage0 (use our changes)
 		if samePath(ours, theirs, path) {
-			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 			continue
 		}
 
 		// If stage1 and stage2 are the same, our branch didn't do anything,
 		// but theirs did, so take their changes.
 		if samePath(base, ours, path) {
-			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 			continue
 		}
 
@@ -128,7 +128,7 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// so take our changes
 		if samePath(base, theirs, path) {
 			if o, ok := ours[path]; ok {
-				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 				continue
 			}
 		}
@@ -140,13 +140,13 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		idx.RemoveFile(path)
 
 		if b, ok := base[path]; ok {
-			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 		}
 		if o, ok := ours[path]; ok {
-			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 		}
 		if t, ok := theirs[path]; ok {
-			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
+			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), UpdateIndexOptions{Add: true})
 		}
 	}
 	if err := checkMergeAndUpdate(c, opt, origMap, idx); err != nil {

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -113,14 +113,14 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// If both stage2 and stage3 are the same, the work has been done in
 		// both branches, so collapse to stage0 (use our changes)
 		if samePath(ours, theirs, path) {
-			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), true)
+			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), true, false)
 			continue
 		}
 
 		// If stage1 and stage2 are the same, our branch didn't do anything,
 		// but theirs did, so take their changes.
 		if samePath(base, ours, path) {
-			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), true)
+			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), true, false)
 			continue
 		}
 
@@ -128,7 +128,7 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// so take our changes
 		if samePath(base, theirs, path) {
 			if o, ok := ours[path]; ok {
-				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), true)
+				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), true, false)
 				continue
 			}
 		}
@@ -140,13 +140,13 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		idx.RemoveFile(path)
 
 		if b, ok := base[path]; ok {
-			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), true)
+			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), true, false)
 		}
 		if o, ok := ours[path]; ok {
-			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), true)
+			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), true, false)
 		}
 		if t, ok := theirs[path]; ok {
-			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), true)
+			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), true, false)
 		}
 	}
 	if err := checkMergeAndUpdate(c, opt, origMap, idx); err != nil {

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -113,14 +113,14 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// If both stage2 and stage3 are the same, the work has been done in
 		// both branches, so collapse to stage0 (use our changes)
 		if samePath(ours, theirs, path) {
-			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), true, false)
+			idx.AddStage(c, path, ours[path].Mode, ours[path].Sha1, Stage0, ours[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 			continue
 		}
 
 		// If stage1 and stage2 are the same, our branch didn't do anything,
 		// but theirs did, so take their changes.
 		if samePath(base, ours, path) {
-			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), true, false)
+			idx.AddStage(c, path, theirs[path].Mode, theirs[path].Sha1, Stage0, theirs[path].Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 			continue
 		}
 
@@ -128,7 +128,7 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		// so take our changes
 		if samePath(base, theirs, path) {
 			if o, ok := ours[path]; ok {
-				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), true, false)
+				idx.AddStage(c, path, o.Mode, o.Sha1, Stage0, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 				continue
 			}
 		}
@@ -140,13 +140,13 @@ func ReadTreeMerge(c *Client, opt ReadTreeOptions, stage1, stage2, stage3 Treeis
 		idx.RemoveFile(path)
 
 		if b, ok := base[path]; ok {
-			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), true, false)
+			idx.AddStage(c, path, b.Mode, b.Sha1, Stage1, b.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 		}
 		if o, ok := ours[path]; ok {
-			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), true, false)
+			idx.AddStage(c, path, o.Mode, o.Sha1, Stage2, o.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 		}
 		if t, ok := theirs[path]; ok {
-			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), true, false)
+			idx.AddStage(c, path, t.Mode, t.Sha1, Stage3, t.Fsize, time.Now().UnixNano(), UpdateIndexOptions{ Add: true })
 		}
 	}
 	if err := checkMergeAndUpdate(c, opt, origMap, idx); err != nil {

--- a/git/reset.go
+++ b/git/reset.go
@@ -157,7 +157,7 @@ func ResetUnstage(c *Client, opts ResetOptions, tree Treeish, files []File) erro
 					index.RemoveFile(entry.Name)
 				}
 			}
-		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, UpdateIndexOptions{ Add: true }); err != nil {
+		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, UpdateIndexOptions{Add: true}); err != nil {
 			return err
 		}
 	}

--- a/git/reset.go
+++ b/git/reset.go
@@ -157,7 +157,7 @@ func ResetUnstage(c *Client, opts ResetOptions, tree Treeish, files []File) erro
 					index.RemoveFile(entry.Name)
 				}
 			}
-		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, true); err != nil {
+		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, true, false); err != nil {
 			return err
 		}
 	}

--- a/git/reset.go
+++ b/git/reset.go
@@ -157,7 +157,7 @@ func ResetUnstage(c *Client, opts ResetOptions, tree Treeish, files []File) erro
 					index.RemoveFile(entry.Name)
 				}
 			}
-		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, true, false); err != nil {
+		} else if err := index.AddStage(c, entry.Name, entry.Src.FileMode, entry.Src.Sha1, Stage0, uint32(entry.SrcSize), mtime, UpdateIndexOptions{ Add: true }); err != nil {
 			return err
 		}
 	}

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -145,7 +145,7 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 				if err != nil {
 					return nil, err
 				}
-				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, UpdateIndexOptions{ Add: true }); err != nil {
+				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, UpdateIndexOptions{Add: true}); err != nil {
 					return nil, err
 				}
 			}

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -88,7 +88,7 @@ func UpdateIndex(c *Client, idx *Index, opts UpdateIndexOptions, files []File) (
 			} else {
 				return nil, fmt.Errorf("%v does not exist and --remove not passed", file)
 			}
-		} else if err := idx.AddFile(c, file, opts.Add); err != nil {
+		} else if err := idx.AddFile(c, file, opts.Add, opts.Replace); err != nil {
 			if !opts.Add {
 				// This is making invalid assumptions that the only
 				// thing that might go wrong is that createEntry was
@@ -142,7 +142,7 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 				if err != nil {
 					return nil, err
 				}
-				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, true); err != nil {
+				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, true, false); err != nil {
 					return nil, err
 				}
 			}

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -91,7 +91,7 @@ func UpdateIndex(c *Client, idx *Index, opts UpdateIndexOptions, files []File) (
 			} else {
 				return nil, fmt.Errorf("%v does not exist and --remove not passed", file)
 			}
-		} else if err := idx.AddFile(c, file, opts.Add, opts.Replace); err != nil {
+		} else if err := idx.AddFile(c, file, opts); err != nil {
 			if !opts.Add {
 				// This is making invalid assumptions that the only
 				// thing that might go wrong is that createEntry was
@@ -145,7 +145,7 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 				if err != nil {
 					return nil, err
 				}
-				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, true, false); err != nil {
+				if err := idx.AddStage(c, IndexPath(path), mode, sha1, Stage0, 0, 0, UpdateIndexOptions{ Add: true }); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
This PR hooks in replace functionality when specified that will search the index for existing entries based on sha1 hash and sub-paths and remove them.