### PR TITLE
Include long filename support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ script:
     - diff -u <(echo -n) <(gofmt -d ./)
     - go test -v ./...
     - chmod u+x ./official-git/run-tests.sh
-    - GIT_SKIP_TESTS=t0000.77 ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
+    - ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
 

--- a/git/file.go
+++ b/git/file.go
@@ -133,3 +133,12 @@ func (f File) Remove() error {
 func (f File) Open() (*os.File, error) {
 	return os.Open(f.String())
 }
+
+// Returns true if f matches the filesystem glob pattern pattern.
+func (f File) MatchGlob(pattern string) bool {
+	m, err := filepath.Match(pattern, string(f))
+	if err != nil {
+		panic(err)
+	}
+	return m
+}

--- a/git/index.go
+++ b/git/index.go
@@ -196,7 +196,8 @@ func ReadIndexEntry(file *os.File) (*IndexEntry, error) {
 		if err != nil {
 			return nil, err
 		}
-		padding := 8 - (off % 8) + 4
+		// The mystery 4 appears again.
+		padding := 8 - ((off + 4) % 8)
 		if _, err := file.Seek(padding, os.SEEK_CUR); err != nil {
 			return nil, err
 		}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"io/ioutil"
+	//"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,6 +139,10 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 					return nil, err
 				}
 				if fAbs == eAbs || strings.HasPrefix(fAbs, eAbs+"/") {
+					skip = false
+					break
+				}
+				if f.MatchGlob(explicit.String()) {
 					skip = false
 					break
 				}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"io/ioutil"
-	//"fmt"
 	"os"
 	"path/filepath"
 	"strings"

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -129,9 +129,32 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 			return nil, fmt.Errorf("update-index --index-info variant 1 not implemented")
 		case 3:
 			switch len(spaces[1]) {
-			case 20:
+			case 40:
 				// mode SP sha1 SP stage TAB path
-				return nil, fmt.Errorf("update-index --index-info variant 3 not implemented")
+				mode, err := ModeFromString(spaces[0])
+				if err != nil {
+					return nil, err
+				}
+				sha1, err := Sha1FromString(spaces[1])
+				if err != nil {
+					return nil, err
+				}
+				var stage Stage
+				switch spaces[2] {
+				case "0":
+					stage = Stage0
+				case "1":
+					stage = Stage1
+				case "2":
+					stage = Stage2
+				case "3":
+					stage = Stage3
+				default:
+					return nil, fmt.Errorf("Invalid stage: %v", spaces[2])
+				}
+				if err := idx.AddStage(c, IndexPath(path), mode, sha1, stage, 0, 0, UpdateIndexOptions{Add: true}); err != nil {
+					return nil, err
+				}
 			default:
 				// mode SP type SP sha1 TAB path
 				mode, err := ModeFromString(spaces[0])


### PR DESCRIPTION
This adds support for reading long filenames into the index, as well as fixes two other bugs preventing the last t0000-basic test from passing.