### PR TITLE
Fix dgit clone (#40)

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -67,7 +67,7 @@ func Clone(c *git.Client, args []string) error {
 	}
 
 	if err := Config(c, []string{"remote.origin.url", repoid}); err != nil {
-		return nil
+		return err
 	}
 	if err := Config(c, []string{"branch.master.remote", "origin"}); err != nil {
 		return err

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -66,12 +66,18 @@ func Clone(c *git.Client, args []string) error {
 		return err
 	}
 
-	Config(c, []string{"remote.origin.url", repoid})
-	Config(c, []string{"branch.master.remote", "origin"})
+	if err := Config(c, []string{"remote.origin.url", repoid}); err != nil {
+		return nil
+	}
+	if err := Config(c, []string{"branch.master.remote", "origin"}); err != nil {
+		return err
+	}
 
 	// This should be smarter and try and get the HEAD branch from Fetch.
 	// The HEAD refspec isn't necessarily named refs/heads/master.
-	Config(c, []string{"branch.master.merge", "refs/heads/master"})
+	if err := Config(c, []string{"branch.master.merge", "refs/heads/master"}); err != nil {
+		return err
+	}
 
 	Fetch(c, []string{"origin"})
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -66,12 +66,12 @@ func Clone(c *git.Client, args []string) error {
 		return err
 	}
 
-	Config(c, []string{"--set", "remote.origin.url", repoid})
-	Config(c, []string{"--set", "branch.master.remote", "origin"})
+	Config(c, []string{"remote.origin.url", repoid})
+	Config(c, []string{"branch.master.remote", "origin"})
 
 	// This should be smarter and try and get the HEAD branch from Fetch.
 	// The HEAD refspec isn't necessarily named refs/heads/master.
-	Config(c, []string{"--set", "branch.master.merge", "refs/heads/master"})
+	Config(c, []string{"branch.master.merge", "refs/heads/master"})
 
 	Fetch(c, []string{"origin"})
 


### PR DESCRIPTION
Clone command was broken when #40 removed `--set` switch.