### PR TITLE
Fix option name in ls-files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ script:
     - diff -u <(echo -n) <(gofmt -d ./)
     - go test -v ./...
     - chmod u+x ./official-git/run-tests.sh
-    - GIT_SKIP_TESTS='t0008.30[5-9] t0008.310 t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2]' ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0008-ignores.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
+    - GIT_SKIP_TESTS='t0008.30[5-9] t0008.310 t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2]' ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0008-ignores.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t3002-ls-files-dashpath.sh t3006-ls-files-long.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
     - ./dgit clone https://github.com/driusan/dgit.git /tmp/dgit.$$
 

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -28,7 +28,7 @@ func LsFiles(c *git.Client, args []string) error {
 	modified := flags.Bool("modified", false, "Show modified files in output")
 	m := flags.Bool("m", false, "Alias of --modified")
 
-	others := flags.Bool("other", false, "Show other (ie. untracked) files in output")
+	others := flags.Bool("others", false, "Show other (ie. untracked) files in output")
 	o := flags.Bool("o", false, "Alias of --others")
 
 	ignored := flags.Bool("ignored", false, "Show only ignored files in output")


### PR DESCRIPTION
It's "--others", not "--other". This fixes two of the ls-files tests
where that was the only problem.