### PR TITLE
Add git diff --exit-code option

### DIFF
--- a/cmd/commondiff.go
+++ b/cmd/commondiff.go
@@ -23,6 +23,7 @@ func parseCommonDiffFlags(c *git.Client, options *git.DiffCommonOptions, default
 	unified := flags.Int("unified", 3, "Generate <n> lines of context")
 	U := flags.Int("U", 3, "Alias of --unified")
 	flags.BoolVar(&options.Raw, "raw", true, "Generate the diff in raw format")
+	flags.BoolVar(&options.ExitCode, "exit-code", false, "Exit with an exit code of 1 if there are any diffs")
 
 	flags.Parse(args)
 	args = flags.Args()
@@ -52,5 +53,13 @@ func parseCommonDiffFlags(c *git.Client, options *git.DiffCommonOptions, default
 // Print the diffs that come back from either diff-files, diff-index, or diff-tree
 // in the appropriate format according to options.
 func printDiffs(c *git.Client, options git.DiffCommonOptions, diffs []git.HashDiff) error {
-	return git.GeneratePatch(c, options, diffs, nil)
+	if err := git.GeneratePatch(c, options, diffs, nil); err != nil {
+		return err
+	}
+	if options.ExitCode {
+		if len(diffs) > 0 {
+			os.Exit(1)
+		}
+	}
+	return nil
 }

--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -15,6 +15,9 @@ type DiffCommonOptions struct {
 
 	// Generate the diff in raw format, not a unified diff
 	Raw bool
+
+	// Exit with a exit code of 1 if there are any diffs
+	ExitCode bool
 }
 
 // Describes the options that may be specified on the command line for


### PR DESCRIPTION
A number of tests use this option, so this gets them closer to passing
(though doesn't get any of them all of the way there.)