### PR TITLE
Add inode to stat information which is compared

### DIFF
--- a/git/difffiles.go
+++ b/git/difffiles.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"log"
 	"sort"
 )
 
@@ -74,27 +73,18 @@ func DiffFiles(c *Client, opt DiffFilesOptions, paths []File) ([]HashDiff, error
 		default:
 			fs.FileMode = ModeBlob
 		}
-		mtime, err := f.MTime()
-		if err != nil {
-			return nil, err
-		}
 		size := stat.Size()
-		ctm, ctmn := f.CTime()
-		log.Printf("%v: Mtime %v idxmtime %v Size: %v idxsize: %v ctime: %v ctimenano:%v\n", f, mtime, idx.Mtime, size, idx.Fsize, idx.Ctime, idx.Ctimenano)
-		if mtime != idx.Mtime || size != int64(idx.Fsize) || ctm != idx.Ctime || ctmn != idx.Ctimenano {
+		if idx.CompareStat(f) != nil {
 			val = append(val, HashDiff{idx.PathName, idxtree, fs, uint(idx.Fsize), uint(size)})
 			continue
 		}
 
-		// The real git client appears to only compare lstat information and not hash the file. In fact,
-		// if we hash the file then the official git test suite fails on the basic tests. Go, unfortunately,
-		// only exposes mtime in an easy, cross-platform way, not ctime without going through the sys package
-		if idx.Ctime == 0 {
-			hash, _, err := HashFile("blob", f.String())
+		// We couldn't short-circuit by checking the stat info, so fall back on hashing
+		// the file.
+		hash, _, err := HashFile("blob", f.String())
 
-			if err != nil || hash != idx.Sha1 {
-				val = append(val, HashDiff{idx.PathName, idxtree, fs, uint(idx.Fsize), uint(size)})
-			}
+		if err != nil || hash != idx.Sha1 {
+			val = append(val, HashDiff{idx.PathName, idxtree, fs, uint(idx.Fsize), uint(size)})
 		}
 	}
 

--- a/git/file_inode_darwin.go
+++ b/git/file_inode_darwin.go
@@ -1,0 +1,14 @@
+package git
+
+import (
+	"syscall"
+)
+
+func (f File) INode() uint32 {
+	stat, err := f.Lstat()
+	if err != nil {
+		return 0, 0
+	}
+	rawstat := stat.Sys().(*syscall.Stat_t)
+	return int32(rawstat.Ino)
+}

--- a/git/file_inode_other.go
+++ b/git/file_inode_other.go
@@ -1,0 +1,9 @@
+// +build !dragonfly
+// +build !darwin
+// +build !linux
+
+package git
+
+func (f File) Inode() uint32 {
+	return 0
+}

--- a/git/file_inode_unix.go
+++ b/git/file_inode_unix.go
@@ -1,0 +1,16 @@
+// +build dragonfly linux
+
+package git
+
+import (
+	"syscall"
+)
+
+func (f File) INode() uint32 {
+	stat, err := f.Lstat()
+	if err != nil {
+		return 0
+	}
+	rawstat := stat.Sys().(*syscall.Stat_t)
+	return uint32(rawstat.Ino)
+}

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -621,18 +622,12 @@ func checkMergeAndUpdate(c *Client, opt ReadTreeOptions, origidx map[IndexPath]*
 
 		// Update stat information for things changed by CheckoutIndex.
 		for _, entry := range newidx.Objects {
-			fname, err := entry.PathName.FilePath(c)
-			if err != nil {
-				return err
-			}
-			if _, ok := filemap[fname]; ok {
-				mtime, err := fname.MTime()
-				if err == nil && mtime != entry.Mtime {
-					entry.Mtime = mtime
-				}
+			if err := entry.RefreshStat(c); err != nil {
+				// The error is likely just "no such file or directory", but
+				// trace it just in case.
+				log.Println(err)
 			}
 		}
-
 	}
 	return nil
 }

--- a/git/readtree_test.go
+++ b/git/readtree_test.go
@@ -71,6 +71,9 @@ func TestReadTreeThreeWayConflict(t *testing.T) {
 		t.Errorf("ReadTree error: %v", err)
 	}
 
+	if idx == nil {
+		t.Fatalf("Got nil index from read-tree")
+	}
 	if len(idx.Objects) != 3 {
 		t.Fatalf("Unexpected number of stages in tree. Got %v want %v", len(idx.Objects), 3)
 	}


### PR DESCRIPTION
This allows use to include a hash of the file when comparing
with diff-files.

Also fixed a bug where HashFile wasn't working correctly with
symlinks (which it turns out was the real cause of the problem causing
some basic tests to fail, not the fact that the file isn't supposed to
be hashed).