### PR TITLE
Add ls-files --no-empty directory and fix file sorting order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ script:
     - diff -u <(echo -n) <(gofmt -d ./)
     - go test -v ./...
     - chmod u+x ./official-git/run-tests.sh
-    - GIT_SKIP_TESTS='t0008.30[5-9] t0008.310 t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2]' ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0008-ignores.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1000-read-tree-m-3way.sh t1001-read-tree-m-2way.sh t1002-read-tree-m-u-2way.sh t1003-read-tree-prefix.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t3002-ls-files-dashpath.sh t3006-ls-files-long.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
+    # t0008 tests that are skipped require ! to negate a pattern. (GitHub issue #72)
+    # t3000.7 requires git pack-refs
+    - GIT_SKIP_TESTS='t0008.30[5-9] t0008.310 t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2] t3000.7' ./official-git/run-tests.sh t0000-basic.sh t0004-unwritable.sh t0007-git-var.sh t0008-ignores.sh t0010-racy-git.sh t0062-revision-walking.sh t0070-fundamental.sh t0081-line-buffer.sh t1000-read-tree-m-3way.sh t1001-read-tree-m-2way.sh t1002-read-tree-m-u-2way.sh t1003-read-tree-prefix.sh t1009-read-tree-new-index.sh t1304-default-acl.sh t2100-update-cache-badpath.sh t3000-ls-files-others.sh t3002-ls-files-dashpath.sh t3006-ls-files-long.sh t4113-apply-ending.sh t4123-apply-shrink.sh t5705-clone-2gb.sh t7062-wtstatus-ignorecase.sh t7511-status-index.sh
     - ./dgit clone https://github.com/driusan/dgit.git /tmp/dgit.$$

--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -43,6 +43,7 @@ func LsFiles(c *git.Client, args []string) error {
 	flags.BoolVar(&options.ExcludeStandard, "exclude-standard", false, "Add the standard Git exclusions.")
 
 	flags.BoolVar(&options.Directory, "directory", false, "Show only directory, not its contents if a directory is untracked")
+	flags.BoolVar(&options.NoEmptyDirectory, "no-empty-directory", false, "Do not show empty untracked directories in output")
 
 	flags.Var(newAliasedStringValue(&options.ExcludePattern, ""), "exclude", "Skip untracked files matching pattern.")
 	flags.Var(newAliasedStringValue(&options.ExcludePattern, ""), "x", "Alias for --exclude")
@@ -105,7 +106,11 @@ func LsFiles(c *git.Client, args []string) error {
 		if options.Stage {
 			fmt.Printf("%o %v %v\t%v\n", file.Mode, file.Sha1, file.Stage(), path)
 		} else {
-			fmt.Println(path)
+			if options.Directory && path.IsDir() {
+				fmt.Println(path + "/")
+			} else {
+				fmt.Println(path)
+			}
 		}
 	}
 	return err

--- a/git/index.go
+++ b/git/index.go
@@ -561,24 +561,26 @@ func (g ByPath) Less(i, j int) bool {
 	if g[i].PathName == g[j].PathName {
 		return g[i].Stage() < g[j].Stage()
 	}
-	for k := range g[i].PathName {
-		if k >= len(g[j].PathName) {
+	ibytes := []byte(g[i].PathName)
+	jbytes := []byte(g[j].PathName)
+	for k := range ibytes {
+		if k >= len(jbytes) {
 			// We reached the end of j and there was stuff
 			// leftover in i, so i > j
-			return true
+			return false
 		}
 
 		// If a character is not equal, return if it's
 		// less or greater
-		if g[i].PathName[k] < g[j].PathName[k] {
+		if ibytes[k] < jbytes[k] {
 			return true
-		} else if g[i].PathName[k] > g[j].PathName[k] {
+		} else if ibytes[k] > jbytes[k] {
 			return false
 		}
 	}
 	// Everything equal up to the end of i, and there is stuff
 	// left in j, so i < j
-	return false
+	return true
 }
 
 // Replaces the index of Client with the the tree from the provided Treeish.

--- a/git/index.go
+++ b/git/index.go
@@ -558,13 +558,27 @@ type ByPath []*IndexEntry
 func (g ByPath) Len() int      { return len(g) }
 func (g ByPath) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
 func (g ByPath) Less(i, j int) bool {
-	if g[i].PathName < g[j].PathName {
-		return true
-	} else if g[i].PathName == g[j].PathName {
+	if g[i].PathName == g[j].PathName {
 		return g[i].Stage() < g[j].Stage()
-	} else {
-		return false
 	}
+	for k := range g[i].PathName {
+		if k >= len(g[j].PathName) {
+			// We reached the end of j and there was stuff
+			// leftover in i, so i > j
+			return true
+		}
+
+		// If a character is not equal, return if it's
+		// less or greater
+		if g[i].PathName[k] < g[j].PathName[k] {
+			return true
+		} else if g[i].PathName[k] > g[j].PathName[k] {
+			return false
+		}
+	}
+	// Everything equal up to the end of i, and there is stuff
+	// left in j, so i < j
+	return false
 }
 
 // Replaces the index of Client with the the tree from the provided Treeish.

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -278,6 +278,12 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				if err != nil {
 					return nil, err
 				}
+				// Add a "/" if --directory is set so that it sorts properly in some
+				// edge cases.
+				if match.PathName.IsDir() && opt.Directory {
+					indexPath += "/"
+
+				}
 				fs = append(fs, &IndexEntry{PathName: indexPath})
 			}
 		}


### PR DESCRIPTION
Go string comparison doesn't produce the same output as git (which
uses memcmp order) for sorting files, so this updates the sort.ByPath
to emulate memcmp in order to make it easier to compare test output
between git and dgit.