### PR TITLE
Allow multiple exclude patterns or exclude files in Ls-files

### DIFF
--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -45,15 +45,24 @@ func LsFiles(c *git.Client, args []string) error {
 	flags.BoolVar(&options.Directory, "directory", false, "Show only directory, not its contents if a directory is untracked")
 	flags.BoolVar(&options.NoEmptyDirectory, "no-empty-directory", false, "Do not show empty untracked directories in output")
 
-	flags.Var(newAliasedStringValue(&options.ExcludePattern, ""), "exclude", "Skip untracked files matching pattern.")
-	flags.Var(newAliasedStringValue(&options.ExcludePattern, ""), "x", "Alias for --exclude")
+	var excludefiles, excludeperdirectory []string
+	flags.Var(newMultiStringValue(&options.ExcludePatterns), "exclude", "Skip untracked files matching pattern.")
+	flags.Var(newMultiStringValue(&options.ExcludePatterns), "x", "Alias for --exclude")
 
-	flags.Var(newAliasedStringValue(&options.ExcludeFile, ""), "exclude-from", "Read exclude patterns from a file.")
-	flags.Var(newAliasedStringValue(&options.ExcludeFile, ""), "X", "Alias for --exclude-from")
+	flags.Var(newMultiStringValue(&excludefiles), "exclude-from", "Read exclude patterns from a file.")
+	flags.Var(newMultiStringValue(&excludefiles), "X", "Alias for --exclude-from")
+
+	flags.Var(newMultiStringValue(&excludeperdirectory), "exclude-per-directory", "Read additional exclude patterns for each directory.")
 
 	flags.Parse(args)
 	oargs := flags.Args()
 
+	for _, f := range excludefiles {
+		options.ExcludeFiles = append(options.ExcludeFiles, git.File(f))
+	}
+	for _, f := range excludeperdirectory {
+		options.ExcludePerDirectory = append(options.ExcludePerDirectory, git.File(f))
+	}
 	options.Cached = *cached || *ca
 
 	rdeleted := *deleted || *d

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -102,11 +102,14 @@ type LsFilesOptions struct {
 	// Exclude standard patterns (ie. .gitignore and .git/info/exclude)
 	ExcludeStandard bool
 
-	// Exclude using the provided pattern
-	ExcludePattern string
+	// Exclude using the provided patterns
+	ExcludePatterns []string
 
 	// Exclude using the provided file with the patterns
-	ExcludeFile string
+	ExcludeFiles []File
+
+	// Exclude using additional patterns from each directory
+	ExcludePerDirectory []File
 }
 
 // LsFiles implements the git ls-files command. It returns an array of files
@@ -256,11 +259,12 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 			}
 			ignorePatterns = append(ignorePatterns, standardPatterns...)
 		}
-		if opt.ExcludePattern != "" {
-			ignorePatterns = append(ignorePatterns, IgnorePattern{Pattern: opt.ExcludePattern, Source: "", LineNum: 1, Scope: ""})
+		for _, pattern := range opt.ExcludePatterns {
+			ignorePatterns = append(ignorePatterns, IgnorePattern{Pattern: pattern, Source: "", LineNum: 1, Scope: ""})
 		}
-		if opt.ExcludeFile != "" {
-			patterns, err := ParseIgnorePatterns(c, File(opt.ExcludeFile), File(""))
+
+		for _, file := range opt.ExcludeFiles {
+			patterns, err := ParseIgnorePatterns(c, file, "")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Add support for multiple exclude patterns, and add command line
parsing for --exclude-per-directory (which isn't implemented.)