### PR TITLE
Add git ls-files --exclude-per-directory support

### DIFF
--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,15 +11,43 @@ import (
 
 // Finds things that aren't tracked, and creates fake IndexEntrys for them to be merged into
 // the output if --others is passed.
-func findUntrackedFilesFromDir(c *Client, root, parent, dir File, tracked map[IndexPath]bool, recursedir bool) (untracked []*IndexEntry) {
+func findUntrackedFilesFromDir(c *Client, opts LsFilesOptions, root, parent, dir File, tracked map[IndexPath]bool, recursedir bool, ignorePatterns []IgnorePattern) (untracked []*IndexEntry) {
 	files, err := ioutil.ReadDir(dir.String())
 	if err != nil {
 		return nil
 	}
+	for _, ignorefile := range opts.ExcludePerDirectory {
+		ignoreInDir := ignorefile
+		if dir != "" {
+			ignoreInDir = dir + "/" + ignorefile
+		}
+
+		if ignoreInDir.Exists() {
+			log.Println("Adding excludes from", ignoreInDir)
+
+			patterns, err := ParseIgnorePatterns(c, ignoreInDir, dir)
+			if err != nil {
+				panic(err)
+			}
+			ignorePatterns = append(ignorePatterns, patterns...)
+		}
+	}
+files:
 	for _, fi := range files {
 		fname := File(fi.Name())
 		if fi.Name() == ".git" {
 			continue
+		}
+		for _, pattern := range ignorePatterns {
+			var name File
+			if parent == "" {
+				name = fname
+			} else {
+				name = parent + "/" + fname
+			}
+			if pattern.Matches(name.String(), fi.IsDir()) {
+				continue files
+			}
 		}
 		if fi.IsDir() {
 			if !recursedir {
@@ -52,7 +81,7 @@ func findUntrackedFilesFromDir(c *Client, root, parent, dir File, tracked map[In
 				newdir = dir + "/" + fname
 			}
 
-			recurseFiles := findUntrackedFilesFromDir(c, root, newparent, newdir, tracked, recursedir)
+			recurseFiles := findUntrackedFilesFromDir(c, opts, root, newparent, newdir, tracked, recursedir, ignorePatterns)
 			untracked = append(untracked, recurseFiles...)
 		} else {
 			var filePath File
@@ -208,7 +237,22 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 
 	if opt.Others {
 		wd := File(c.WorkDir)
-		others := findUntrackedFilesFromDir(c, wd+"/", wd, wd, filesInIndex, !opt.Directory)
+
+		ignorePatterns := []IgnorePattern{}
+
+		for _, file := range opt.ExcludeFiles {
+			patterns, err := ParseIgnorePatterns(c, file, "")
+			if err != nil {
+				return nil, err
+			}
+			ignorePatterns = append(ignorePatterns, patterns...)
+		}
+
+		for _, pattern := range opt.ExcludePatterns {
+			ignorePatterns = append(ignorePatterns, IgnorePattern{Pattern: pattern, Source: "", LineNum: 1, Scope: ""})
+		}
+
+		others := findUntrackedFilesFromDir(c, opt, wd+"/", wd, wd, filesInIndex, !opt.Directory, ignorePatterns)
 		otherFiles := make([]File, 0, len(others))
 
 		for _, file := range others {
@@ -250,25 +294,12 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 			otherFiles = append(otherFiles, f)
 		}
 
-		ignorePatterns := []IgnorePattern{}
-
 		if opt.ExcludeStandard {
 			standardPatterns, err := StandardIgnorePatterns(c, otherFiles)
 			if err != nil {
 				return nil, err
 			}
 			ignorePatterns = append(ignorePatterns, standardPatterns...)
-		}
-		for _, pattern := range opt.ExcludePatterns {
-			ignorePatterns = append(ignorePatterns, IgnorePattern{Pattern: pattern, Source: "", LineNum: 1, Scope: ""})
-		}
-
-		for _, file := range opt.ExcludeFiles {
-			patterns, err := ParseIgnorePatterns(c, file, "")
-			if err != nil {
-				return nil, err
-			}
-			ignorePatterns = append(ignorePatterns, patterns...)
 		}
 
 		matches, err := MatchIgnores(c, ignorePatterns, otherFiles)

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -65,6 +65,14 @@ files:
 					}
 				}
 				if !dirHasTracked {
+					if opts.Directory {
+						if opts.NoEmptyDirectory {
+							if files, err := ioutil.ReadDir(fname.String()); len(files) == 0 && err == nil {
+								continue
+							}
+						}
+						indexPath += "/"
+					}
 					untracked = append(untracked, &IndexEntry{PathName: indexPath})
 					continue
 				}
@@ -283,15 +291,6 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				if skip {
 					continue
 				}
-			}
-
-			if f.IsDir() && opt.Directory {
-				if opt.NoEmptyDirectory {
-					if files, err := ioutil.ReadDir(f.String()); len(files) == 0 && err == nil {
-						continue
-					}
-				}
-				f += "/"
 			}
 
 			fs = append(fs, file)

--- a/status.txt
+++ b/status.txt
@@ -131,7 +131,7 @@ diff-files     HappyPath     git 2.9.2              (~53) no options, but basic 
 diff-index     HappyPath     git 2.9.2              (53) no options, but basic behaviour should match real git.
 diff-tree      HappyPath     git 2.9.2              (~53) Only -r option is implemented
 for-each-ref   None
-ls-files       HappyPath     git 2.9.2              (16) Only --cached, --deleted, --modified, --others, --staged, --unmerged, and --directory implemented
+ls-files       HappyPath     git 2.9.2              (14) Only --cached, --deleted, --modified, --others, --staged, --unmerged, and --directory, --no-empty-directory, --exclude --exclude-per-directory, --exclude-standard implemented
 ls-remote      None
 ls-tree        Done          git 2.9.2
 merge-base     HappyPath     git 2.9.2              only --octopus and --is-ancestor options


### PR DESCRIPTION
This moves pattern matching into the source of findUntrackedFilesPerDirectory so that the `--exclude-per-directory` can be added,  option can be added.

It also refactors --exclude-standard to be an alias of `--exclude-per-directory=.gitignore --exclude-from=info/exclude`