### PR TITLE
Add Ls-files --killed option

### DIFF
--- a/cmd/lsfiles.go
+++ b/cmd/lsfiles.go
@@ -40,6 +40,9 @@ func LsFiles(c *git.Client, args []string) error {
 	unmerged := flags.Bool("unmerged", false, "Show unmerged files. Implies --stage")
 	u := flags.Bool("u", false, "Alias of --unmerged")
 
+	flags.BoolVar(&options.Killed, "killed", false, "Show files that need to be removed for checkout-index to succeed")
+	flags.BoolVar(&options.Killed, "k", false, "Alias of --killed")
+
 	flags.BoolVar(&options.ExcludeStandard, "exclude-standard", false, "Add the standard Git exclusions.")
 
 	flags.BoolVar(&options.Directory, "directory", false, "Show only directory, not its contents if a directory is untracked")

--- a/git/checkoutindex.go
+++ b/git/checkoutindex.go
@@ -131,6 +131,12 @@ func checkoutFile(c *Client, entry *IndexEntry, opts CheckoutIndexOptions) error
 				}
 			}
 
+			if f := File(path); f.Exists() && !f.IsDir() {
+				if err := os.Remove(path); err != nil {
+					return err
+				}
+
+			}
 			if err := os.MkdirAll(path, 0755); err != nil {
 				return err
 			}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -130,6 +130,9 @@ type LsFilesOptions struct {
 	// Show files which are unmerged. Implies Stage.
 	Unmerged bool
 
+	// Show files which need to be removed for checkout-index to succeed
+	Killed bool
+
 	// If a directory is classified as "other", show only its name, not
 	// its contents
 	Directory bool
@@ -172,6 +175,30 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 		f, err := entry.PathName.FilePath(c)
 		if err != nil {
 			return nil, err
+		}
+		if opt.Killed {
+			// We go through each parent to check if it exists on the filesystem
+			// until we find a directory (which means there's no more files getting
+			// in the way of os.MkdirAll from succeeding in CheckoutIndex)
+			pathparent := filepath.Clean(f.String())
+			for pathparent != "" && pathparent != "." {
+				f := File(pathparent)
+				if f.IsDir() {
+					// We found a directory, so there's nothing
+					// getting in the way
+					break
+				} else if f.Exists() {
+					// It's not a directory but it exists, so we need to
+					// delete it
+					indexPath, err := f.IndexPath(c)
+					if err != nil {
+						return nil, err
+					}
+					fs = append(fs, &IndexEntry{PathName: indexPath})
+				}
+				// check the next level of the directory path
+				pathparent, _ = filepath.Split(filepath.Clean(pathparent))
+			}
 		}
 
 		if opt.Others || opt.ErrorUnmatch {

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -180,7 +181,8 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 			// We go through each parent to check if it exists on the filesystem
 			// until we find a directory (which means there's no more files getting
 			// in the way of os.MkdirAll from succeeding in CheckoutIndex)
-			pathparent := filepath.Clean(f.String())
+			pathparent := filepath.Clean(path.Dir(f.String()))
+
 			for pathparent != "" && pathparent != "." {
 				f := File(pathparent)
 				if f.IsDir() {

--- a/status.txt
+++ b/status.txt
@@ -131,7 +131,7 @@ diff-files     HappyPath     git 2.9.2              (~53) no options, but basic 
 diff-index     HappyPath     git 2.9.2              (53) no options, but basic behaviour should match real git.
 diff-tree      HappyPath     git 2.9.2              (~53) Only -r option is implemented
 for-each-ref   None
-ls-files       HappyPath     git 2.9.2              (14) Only --cached, --deleted, --modified, --others, --staged, --unmerged, and --directory, --no-empty-directory, --exclude --exclude-per-directory, --exclude-standard implemented
+ls-files       HappyPath     git 2.9.2              (11) Missing -z, --with-tree, -t, -v, -f, --full-name, --recurse-submodules, --abbrev, --debug, --eol
 ls-remote      None
 ls-tree        Done          git 2.9.2
 merge-base     HappyPath     git 2.9.2              only --octopus and --is-ancestor options


### PR DESCRIPTION
The logic for determining which files need to be killed was already
done in checkout-index, it just had to be moved to ls-files (with
the actual removal itself still happening in checkout-index.)