### PR TITLE
Add primitive tag subcommand

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/driusan/dgit/git"
+)
+
+// Implements the git tag command line parsing.
+func Tag(c *git.Client, args []string) error {
+	flags := flag.NewFlagSet("tag", flag.ExitOnError)
+	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
+	options := git.TagOptions{}
+
+	flags.BoolVar(&options.Force, "force", false, "Replace an existing tag if it exists")
+	flags.BoolVar(&options.Force, "f", false, "Alias of --force")
+
+	flags.Parse(args)
+	tagnames := flags.Args()
+	switch len(tagnames) {
+	case 0:
+		return fmt.Errorf("Listing tags not implemented")
+	case 1:
+		return git.TagCommit(c, options, tagnames[0], nil)
+	case 2:
+		commit, err := git.RevParseCommitish(c, &git.RevParseOptions{}, tagnames[1])
+		if err != nil {
+			return err
+		}
+		return git.TagCommit(c, options, tagnames[0], commit)
+	default:
+		return fmt.Errorf("Invalid tag usage")
+	}
+}

--- a/git/tag.go
+++ b/git/tag.go
@@ -1,0 +1,33 @@
+package git
+
+import (
+	"fmt"
+)
+
+// TagOptions is a stub for when more of Tag is implemented
+type TagOptions struct {
+	// Replace existing tags instead of erroring out.
+	Force bool
+}
+
+func TagCommit(c *Client, opts TagOptions, tagname string, cmt Commitish) error {
+	refspec := RefSpec("refs/tags/" + tagname)
+	var comm CommitID
+	if cmt == nil {
+		cmmt, err := c.GetHeadCommit()
+		if err != nil {
+			return err
+		}
+		comm = cmmt
+	} else {
+		cmmt, err := cmt.CommitID(c)
+		if err != nil {
+			return err
+		}
+		comm = cmmt
+	}
+	if refspec.File(c).Exists() && !opts.Force {
+		return fmt.Errorf("tag '%v' already exists", tagname)
+	}
+	return UpdateRefSpec(c, UpdateRefOptions{}, refspec, comm, "")
+}

--- a/git/updateref.go
+++ b/git/updateref.go
@@ -23,7 +23,7 @@ type UpdateRefOptions struct {
 func updateReflog(c *Client, create bool, file File, oldvalue, newvalue Commitish, reason string) error {
 	if !file.Exists() {
 		if !create {
-			return fmt.Errorf("Can not create new reflog for %s. --create-reflog not specified.", file)
+			return nil
 		}
 		if err := file.Create(); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -335,6 +335,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(4)
 		}
+	case "tag":
+		if err := cmd.Tag(c, args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	case "var":
 		subcommandUsage = "[variable]"
 		if err := cmd.Var(c, args); err != nil {


### PR DESCRIPTION
This adds a very basic "git tag" command which only includes the -f option and only creates refspecs for the tag specified.

It's primarily to make progress on one of the read-tree test cases which depends on `git tag` for the setup.