### PR TITLE
Slight improvements to read-tree test suite

### DIFF
--- a/git/ignore.go
+++ b/git/ignore.go
@@ -182,6 +182,8 @@ func ParseIgnorePatterns(c *Client, patternFile File, scope File) ([]IgnorePatte
 
 			if err == io.EOF {
 				isEof = true
+			} else if err != nil {
+				return nil, err
 			}
 			break
 		}

--- a/git/lsfiles.go
+++ b/git/lsfiles.go
@@ -29,7 +29,7 @@ func findUntrackedFilesFromDir(c *Client, opts LsFilesOptions, root, parent, dir
 
 			patterns, err := ParseIgnorePatterns(c, ignoreInDir, dir)
 			if err != nil {
-				panic(err)
+				continue
 			}
 			ignorePatterns = append(ignorePatterns, patterns...)
 		}
@@ -289,7 +289,6 @@ func LsFiles(c *Client, opt LsFilesOptions, files []File) ([]*IndexEntry, error)
 				return nil, err
 			}
 			if _, ok := filesInIndex[indexPath]; !ok {
-				fmt.Printf("%v", filesInIndex)
 				return nil, fmt.Errorf("error: pathspec '%v' did not match any file(s) known to git", file)
 			}
 		}

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -555,10 +555,14 @@ func checkMergeAndUpdate(c *Client, opt ReadTreeOptions, origidx map[IndexPath]*
 		(opt.Reset && (opt.Prefix != "" || opt.Merge)) {
 		return fmt.Errorf("Can only specify one of -u, --reset, or --prefix")
 	}
+	if opt.ExcludePerDirectory != "" && !opt.Update {
+		return fmt.Errorf("--exclude-per-directory is meaningless without -u")
+	}
 
 	// Keep a list of index entries to be updated by CheckoutIndex.
-	files := make([]File, 0, len(newidx.Objects))
+	//files := make([]File, 0, len(newidx.Objects))
 	filemap := make(map[File]*IndexEntry)
+	files := make([]File, 0, len(newidx.Objects))
 
 	if opt.Merge || opt.Reset {
 		// Verify that merge won't overwrite anything that's been modified locally.

--- a/git/refspec.go
+++ b/git/refspec.go
@@ -42,6 +42,14 @@ func (r RefSpec) CommitID(c *Client) (CommitID, error) {
 	return CommitIDFromString(v)
 }
 
+func (r RefSpec) TreeID(c *Client) (TreeID, error) {
+	cmt, err := r.CommitID(c)
+	if err != nil {
+		return TreeID{}, err
+	}
+	return cmt.TreeID(c)
+}
+
 // A Branch is a type of RefSpec that lives under refs/heads/ or refs/remotes/heads
 // Use GetBranch to get a valid branch from a branchname, don't cast from string
 type Branch RefSpec

--- a/git/revparse.go
+++ b/git/revparse.go
@@ -127,6 +127,9 @@ func RevParseTreeish(c *Client, opt *RevParseOptions, arg string) (Treeish, erro
 		}
 	}
 
+	if rs := c.GitDir.File("refs/tags/" + File(arg)); rs.Exists() {
+		return RefSpec("refs/tags/" + arg), nil
+	}
 	// arg was not a Sha or a symbolic ref, it might still be a branch.
 	// (This will return an error if arg is an invalid branch.)
 	if b, err := GetBranch(c, arg); err == nil {
@@ -151,6 +154,10 @@ func RevParseCommitish(c *Client, opt *RevParseOptions, arg string) (Commitish, 
 			return b, nil
 		}
 	}
+	if rs := c.GitDir.File("refs/tags/" + File(arg)); rs.Exists() {
+		return RefSpec("refs/tags/" + arg), nil
+	}
+
 	// arg was not a Sha or a valid symbolic ref, it might still be a branch
 	return GetBranch(c, arg)
 }


### PR DESCRIPTION
Parse tags in rev-parse and validate --exclude-per-directory command line options.

This brings t1004 down from 13 failing tests to 10.