### PR TITLE
Add special case for merge-base

### DIFF
--- a/git/mergebase.go
+++ b/git/mergebase.go
@@ -9,6 +9,23 @@ type MergeBaseOptions struct {
 }
 
 func MergeBase(c *Client, options MergeBaseOptions, commits []Commitish) (CommitID, error) {
+	if len(commits) == 2 {
+		// If there's only two commits specified, and one is
+		// an ancestor of the other, than that one is the merge-base
+		cmt0, err := commits[0].CommitID(c)
+		if err != nil {
+			return CommitID{}, err
+		}
+		cmt1, err := commits[1].CommitID(c)
+		if err != nil {
+			return CommitID{}, err
+		}
+		if cmt0.IsAncestor(c, cmt1) {
+			return cmt0, nil
+		} else if cmt1.IsAncestor(c, cmt0) {
+			return cmt1, nil
+		}
+	}
 	if options.Octopus {
 		return MergeBaseOctopus(c, options, commits)
 	}


### PR DESCRIPTION
Add special case for a merge-base containing only
two commits, where if one commit is an ancestor of
the other that is taken as the merge-base without
doing a search. This makes `dgit merge-base A B`
and `dgit merge-base B A` return the same commit in
these cases (which is what real git does), rather
than returning the zero commit in one but the right
commit in the other.