### PR TITLE
Add go.mod file with absolute package name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/driusan/dgit


### PR DESCRIPTION
This adds a go.mod file where the package name is the whole URL, without converting to relative paths.

This should allow us to compile within `$GOPATH` and support older versions of Go while also allowing us to compile outside of $GOPATH with Go >= 1.11.