### PR TITLE
Add support for rev-parse with a path component

### DIFF
--- a/git/revparse.go
+++ b/git/revparse.go
@@ -264,7 +264,7 @@ func RevParse(c *Client, opt RevParseOptions, args []string) (commits []ParsedRe
 					sha = arg
 					exclude = false
 				}
-				if path := strings.Index(arg, ":"); path >= 0 {
+				if strings.Contains(arg, ":") {
 					sha, err := RevParsePath(c, &opt, arg)
 					if err != nil {
 						err2 = err


### PR DESCRIPTION
This adds support for rev-parse of the form "git rev-parse foo:bar"
where foo is a treeish and bar is a path.

This implementation is not very efficient, but seems to match the
output of git, at least in the basic use cases.

Fixes #102