### PR TITLE
Added ability to push new branches

### DIFF
--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/driusan/dgit/git"
 )
@@ -16,14 +17,15 @@ func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 		flags.PrintDefaults()
 	}
 
-	includeObjects := flags.Bool("objects", false, "include non-commit objects in output")
-	quiet := flags.Bool("quiet", false, "prevent printing of revisions")
+	opts := git.RevListOptions{}
+	flags.BoolVar(&opts.Objects, "objects", false, "include non-commit objects in output")
+	flags.BoolVar(&opts.Quiet, "quiet", false, "prevent printing of revisions")
 	flags.Parse(args)
 	args = flags.Args()
 
-	excludeList := make(map[git.Sha1]struct{})
 	// First get a map of excluded commitIDs
-	//func revListExcludeList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, quiet bool) ([]git.Sha1, error) {
+	var excludes []git.Commitish
+	var includes []git.Commitish
 	for _, rev := range args {
 		if rev == "" {
 			continue
@@ -33,109 +35,18 @@ func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 			if err != nil {
 				return nil, fmt.Errorf("%s:%v", rev, err)
 			}
-			for _, commit := range commits {
-				if err := revListExcludeList(c, git.CommitID(commit.Id), excludeList, *includeObjects); err != nil {
-					return nil, err
-				}
+			for _, cmt := range commits {
+				excludes = append(excludes, cmt)
+			}
+		} else {
+			commits, err := RevParse(c, []string{rev})
+			if err != nil {
+				return nil, fmt.Errorf("%s:%v", rev, err)
+			}
+			for _, cmt := range commits {
+				includes = append(includes, cmt)
 			}
 		}
 	}
-	objs := make([]git.Sha1, 0)
-	// Then follow the parents of the non-excluded ones until they hit
-	// something that was excluded.
-	for _, rev := range args {
-		if rev == "" {
-			continue
-		}
-		if rev[0] == '^' && len(rev) > 1 {
-			continue
-		}
-		commits, err := RevParse(c, []string{rev})
-		if err != nil {
-			panic(err)
-		}
-		com, err := commits[0].CommitID(c)
-		if err != nil {
-			return nil, err
-		}
-
-		newobjs, err := revList(c, com, excludeList, *quiet, *includeObjects)
-		if err != nil {
-			return nil, err
-		}
-		objs = append(objs, newobjs...)
-	}
-	return objs, nil
-}
-
-func revList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, quiet, includeobjs bool) ([]git.Sha1, error) {
-	if _, ok := excludeList[git.Sha1(cmt)]; ok {
-		return nil, nil
-	}
-
-	shas := make([]git.Sha1, 0)
-	if !quiet {
-		fmt.Printf("%v\n", cmt)
-	}
-	if includeobjs {
-		objs, err := cmt.GetAllObjectsExcept(c, excludeList)
-		if err != nil {
-			return nil, err
-		}
-		for _, o := range objs {
-			if _, ok := excludeList[o]; !ok {
-				if !quiet {
-					fmt.Printf("%v\n", o)
-				}
-				shas = append(shas, git.Sha1(o))
-			}
-			excludeList[o] = struct{}{}
-		}
-	}
-
-	parents, err := cmt.Parents(c)
-	if err != nil {
-		return nil, err
-	}
-	for _, p := range parents {
-		if _, ok := excludeList[git.Sha1(p)]; ok {
-			continue
-		}
-		shas = append(shas, git.Sha1(p))
-		ancestors, err := revList(c, p, excludeList, quiet, includeobjs)
-		if err != nil {
-			return nil, err
-		}
-		excludeList[git.Sha1(p)] = struct{}{}
-		shas = append(shas, ancestors...)
-	}
-	return shas, nil
-}
-
-func revListExcludeList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, includeobjs bool) error {
-	if _, ok := excludeList[git.Sha1(cmt)]; ok {
-		return nil
-	}
-	excludeList[git.Sha1(cmt)] = struct{}{}
-
-	if includeobjs {
-		_, err := cmt.GetAllObjectsExcept(c, excludeList)
-		if err != nil {
-			return err
-		}
-	}
-	parents, err := cmt.Parents(c)
-	if err != nil {
-		return err
-	}
-	for _, p := range parents {
-		if _, ok := excludeList[git.Sha1(p)]; ok {
-			continue
-		}
-		if err := revListExcludeList(c, p, excludeList, includeobjs); err != nil {
-			return err
-		}
-		excludeList[git.Sha1(p)] = struct{}{}
-	}
-	return nil
+	return git.RevList(c, opts, os.Stdout, includes, excludes)
 }

--- a/cmd/rev-list.go
+++ b/cmd/rev-list.go
@@ -21,8 +21,9 @@ func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 	flags.Parse(args)
 	args = flags.Args()
 
-	excludeList := make(map[string]bool)
+	excludeList := make(map[git.Sha1]struct{})
 	// First get a map of excluded commitIDs
+	//func revListExcludeList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, quiet bool) ([]git.Sha1, error) {
 	for _, rev := range args {
 		if rev == "" {
 			continue
@@ -33,23 +34,32 @@ func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 				return nil, fmt.Errorf("%s:%v", rev, err)
 			}
 			for _, commit := range commits {
-				ancestors, err := commit.Ancestors(c)
-				if err != nil {
-					return nil, fmt.Errorf("%s:%v", rev, err)
+				if err := revListExcludeList(c, git.CommitID(commit.Id), excludeList, *includeObjects); err != nil {
+					return nil, err
 				}
-				for _, allC := range ancestors {
-					excludeList[git.Sha1(allC).String()] = true
-					if *includeObjects {
-						objs, err := allC.GetAllObjects(c)
-						if err != nil {
-							panic(err)
-						}
-						for _, o := range objs {
-							excludeList[o.String()] = true
-						}
+				/*
+					ancestors, err := commit.Ancestors(c)
+					if err != nil {
+						return nil, fmt.Errorf("%s:%v", rev, err)
 					}
+					for _, allC := range ancestors {
+						sha := git.Sha1(allC)
+						if _, ok := excludeList[sha]; ok {
+							continue
+						}
+						excludeList[sha] = (struct{}{})
+						if *includeObjects {
+							objs, err := allC.GetAllObjects(c)
+							if err != nil {
+								panic(err)
+							}
+							for _, o := range objs {
+								excludeList[o] = struct{}{}
+							}
+						}
 
-				}
+					}
+				*/
 			}
 		}
 	}
@@ -67,34 +77,119 @@ func RevList(c *git.Client, args []string) ([]git.Sha1, error) {
 		if err != nil {
 			panic(err)
 		}
-		com := commits[0]
-		ancestors, err := com.Ancestors(c)
+		com, err := commits[0].CommitID(c)
 		if err != nil {
 			return nil, err
 		}
-		for _, allC := range ancestors {
-			if _, ok := excludeList[git.Sha1(allC).String()]; !ok {
-				if !*quiet {
-					fmt.Printf("%v\n", git.Sha1(allC).String())
-				}
-				objs = append(objs, git.Sha1(allC))
-				if *includeObjects {
-					objs2, err := allC.GetAllObjects(c)
-					if err != nil {
-						panic(err)
+
+		newobjs, err := revList(c, com, excludeList, *quiet, *includeObjects)
+		if err != nil {
+			return nil, err
+		}
+		objs = append(objs, newobjs...)
+		/*
+			ancestors, err := com.Ancestors(c)
+			if err != nil {
+				return nil, err
+			}
+			for _, allC := range ancestors {
+				if _, ok := excludeList[git.Sha1(allC)]; !ok {
+					if !*quiet {
+						fmt.Printf("%v\n", git.Sha1(allC))
 					}
-					for _, o := range objs2 {
-						if _, okie := excludeList[o.String()]; !okie {
-							if !*quiet {
-								fmt.Printf("%v\n", o.String())
-							}
-							objs = append(objs, git.Sha1(o))
+					objs = append(objs, git.Sha1(allC))
+					if *includeObjects {
+						objs2, err := allC.GetAllObjects(c)
+						if err != nil {
+							panic(err)
 						}
-						excludeList[o.String()] = true
+						for _, o := range objs2 {
+							if _, okie := excludeList[o]; !okie {
+								if !*quiet {
+									fmt.Printf("%v\n", o.String())
+								}
+								objs = append(objs, git.Sha1(o))
+							}
+							excludeList[o] = true
+						}
 					}
 				}
 			}
-		}
+		*/
 	}
 	return objs, nil
+}
+
+func revList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, quiet, includeobjs bool) ([]git.Sha1, error) {
+	if _, ok := excludeList[git.Sha1(cmt)]; ok {
+		return nil, nil
+	}
+
+	shas := make([]git.Sha1, 0)
+	if !quiet {
+		fmt.Printf("%v\n", cmt)
+		if includeobjs {
+			objs, err := cmt.GetAllObjects(c)
+			if err != nil {
+				return nil, err
+			}
+			for _, o := range objs {
+				if _, ok := excludeList[o]; !ok {
+					if !quiet {
+						fmt.Printf("%v\n", o)
+					}
+					shas = append(shas, git.Sha1(o))
+				}
+				excludeList[o] = struct{}{}
+			}
+		}
+	}
+	parents, err := cmt.Parents(c)
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range parents {
+		if _, ok := excludeList[git.Sha1(p)]; ok {
+			continue
+		}
+		shas = append(shas, git.Sha1(p))
+		ancestors, err := revList(c, p, excludeList, quiet, includeobjs)
+		if err != nil {
+			return nil, err
+		}
+		excludeList[git.Sha1(p)] = struct{}{}
+		shas = append(shas, ancestors...)
+	}
+	return shas, nil
+}
+
+func revListExcludeList(c *git.Client, cmt git.CommitID, excludeList map[git.Sha1]struct{}, includeobjs bool) error {
+	if _, ok := excludeList[git.Sha1(cmt)]; ok {
+		return nil
+	}
+	excludeList[git.Sha1(cmt)] = struct{}{}
+
+	if includeobjs {
+		objs, err := cmt.GetAllObjects(c)
+		if err != nil {
+			return err
+		}
+		for _, o := range objs {
+			excludeList[o] = struct{}{}
+		}
+	}
+	parents, err := cmt.Parents(c)
+	if err != nil {
+		return err
+	}
+	for _, p := range parents {
+		if _, ok := excludeList[git.Sha1(p)]; ok {
+			continue
+		}
+		if err := revListExcludeList(c, p, excludeList, includeobjs); err != nil {
+			return err
+		}
+		excludeList[git.Sha1(p)] = struct{}{}
+	}
+	return nil
 }

--- a/cmd/rev-list_test.go
+++ b/cmd/rev-list_test.go
@@ -12,7 +12,7 @@ func BenchmarkRevListHead(b *testing.B) {
 		panic(err)
 	}
 	for n := 0; n < b.N; n++ {
-		if _, err := RevList(c, []string{"--quiet", "HEAD"}); err != nil {
+		if err := RevList(c, []string{"--quiet", "HEAD"}); err != nil {
 			panic(err)
 		}
 	}
@@ -24,7 +24,7 @@ func BenchmarkRevListHeadExclude(b *testing.B) {
 		panic(err)
 	}
 	for n := 0; n < b.N; n++ {
-		if _, err := RevList(c, []string{"--quiet", "HEAD", "^HEAD^"}); err != nil {
+		if err := RevList(c, []string{"--quiet", "HEAD", "^HEAD^"}); err != nil {
 			panic(err)
 		}
 	}
@@ -36,7 +36,7 @@ func BenchmarkRevListHeadExcludeObjects(b *testing.B) {
 		panic(err)
 	}
 	for n := 0; n < b.N; n++ {
-		if _, err := RevList(c, []string{"--quiet", "--objects", "HEAD", "^HEAD^"}); err != nil {
+		if err := RevList(c, []string{"--quiet", "--objects", "HEAD", "^HEAD^"}); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/rev-list_test.go
+++ b/cmd/rev-list_test.go
@@ -18,7 +18,6 @@ func BenchmarkRevListHead(b *testing.B) {
 	}
 }
 
-/*
 func BenchmarkRevListHeadExclude(b *testing.B) {
 	c, err := git.NewClient("../.git", ".")
 	if err != nil {
@@ -30,4 +29,15 @@ func BenchmarkRevListHeadExclude(b *testing.B) {
 		}
 	}
 }
-*/
+
+func BenchmarkRevListHeadExcludeObjects(b *testing.B) {
+	c, err := git.NewClient("../.git", ".")
+	if err != nil {
+		panic(err)
+	}
+	for n := 0; n < b.N; n++ {
+		if _, err := RevList(c, []string{"--quiet", "--objects", "HEAD", "^HEAD^"}); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/cmd/rev-list_test.go
+++ b/cmd/rev-list_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/driusan/dgit/git"
+)
+
+func BenchmarkRevListHead(b *testing.B) {
+	c, err := git.NewClient("../.git", ".")
+	if err != nil {
+		panic(err)
+	}
+	for n := 0; n < b.N; n++ {
+		if _, err := RevList(c, []string{"--quiet", "HEAD"}); err != nil {
+			panic(err)
+		}
+	}
+}
+
+/*
+func BenchmarkRevListHeadExclude(b *testing.B) {
+	c, err := git.NewClient("../.git", ".")
+	if err != nil {
+		panic(err)
+	}
+	for n := 0; n < b.N; n++ {
+		if _, err := RevList(c, []string{"--quiet", "HEAD", "^HEAD^"}); err != nil {
+			panic(err)
+		}
+	}
+}
+*/

--- a/git/client.go
+++ b/git/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha1"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -85,6 +86,12 @@ type objectLocation struct {
 	packfile File
 }
 
+type fileish interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
 // A Client represents a user of the git command inside of a git repo. It's
 // usually something that is trying to manipulate the repo.
 type Client struct {
@@ -104,6 +111,21 @@ type Client struct {
 
 	// Cache of where this client has previously found existing objects
 	objectCache map[Sha1]objectLocation
+
+	// Things where the closing is deferred until the client is closed.
+	fileclosers map[File]fileish
+
+	objcache map[Sha1]GitObject
+}
+
+func (c *Client) Close() error {
+	var e error
+	for _, f := range c.fileclosers {
+		if err := f.Close(); err != nil {
+			e = err
+		}
+	}
+	return e
 }
 
 // Walks from the current directory to find a .git directory
@@ -151,7 +173,7 @@ func NewClient(gitDir, workDir string) (*Client, error) {
 		// from the gitdir if it doesn't exist.
 	}
 	m := make(map[Sha1]objectLocation)
-	return &Client{GitDir(gitdir), WorkDir(workdir), "", m}, nil
+	return &Client{GitDir(gitdir), WorkDir(workdir), "", m, make(map[File]fileish), make(map[Sha1]GitObject)}, nil
 }
 
 // Returns the branchname of the HEAD branch, or the empty string if the

--- a/git/client.go
+++ b/git/client.go
@@ -92,6 +92,11 @@ type fileish interface {
 	io.Closer
 }
 
+type shaRef struct {
+	Sha1
+	bool
+}
+
 // A Client represents a user of the git command inside of a git repo. It's
 // usually something that is trying to manipulate the repo.
 type Client struct {
@@ -115,7 +120,7 @@ type Client struct {
 	// Things where the closing is deferred until the client is closed.
 	fileclosers map[File]fileish
 
-	objcache map[Sha1]GitObject
+	objcache map[shaRef]GitObject
 }
 
 func (c *Client) Close() error {
@@ -173,7 +178,7 @@ func NewClient(gitDir, workDir string) (*Client, error) {
 		// from the gitdir if it doesn't exist.
 	}
 	m := make(map[Sha1]objectLocation)
-	return &Client{GitDir(gitdir), WorkDir(workdir), "", m, make(map[File]fileish), make(map[Sha1]GitObject)}, nil
+	return &Client{GitDir(gitdir), WorkDir(workdir), "", m, make(map[File]fileish), make(map[shaRef]GitObject)}, nil
 }
 
 // Returns the branchname of the HEAD branch, or the empty string if the

--- a/git/config.go
+++ b/git/config.go
@@ -288,8 +288,7 @@ func LoadLocalConfig(c *Client) (GitConfig, error) {
 		return GitConfig{}, err
 	}
 	config := ParseConfig(file)
-	err = file.Close()
-	if err != nil {
+	if err := file.Close(); err != nil {
 		return GitConfig{}, err
 	}
 

--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -101,7 +101,7 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64, meta
 
 	t, _, ref, refoffset, _ := p.ReadHeaderSize(r)
 	var rawdata []byte
-	if !metaOnly {
+	if !metaOnly || t == OBJ_OFS_DELTA || t == OBJ_REF_DELTA {
 		rawdata, _ = p.ReadEntryDataStream(r)
 	}
 	// The way we calculate the hash changes based on if it's a delta

--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -91,7 +91,7 @@ func (idx PackfileIndexV2) WriteIndex(w io.Writer) error {
 }
 
 // Using the index, retrieve an object from the packfile represented by r.
-func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64) (GitObject, error) {
+func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64, metaOnly bool) (GitObject, error) {
 	var p PackfileHeader
 
 	_, err := r.Seek(offset, io.SeekStart)
@@ -100,7 +100,10 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64) (Git
 	}
 
 	t, _, ref, refoffset, _ := p.ReadHeaderSize(r)
-	rawdata, _ := p.ReadEntryDataStream(r)
+	var rawdata []byte
+	if !metaOnly {
+		rawdata, _ = p.ReadEntryDataStream(r)
+	}
 	// The way we calculate the hash changes based on if it's a delta
 	// or not.
 	switch t {
@@ -113,7 +116,7 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64) (Git
 	case OBJ_OFS_DELTA:
 		// Things aren't very consistent with if types are strings, types,
 		// or interfaces, making this far more difficult than it needs to be.
-		base, err := idx.getObjectAtOffset(r, offset-int64(refoffset))
+		base, err := idx.getObjectAtOffset(r, offset-int64(refoffset), metaOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -187,8 +190,9 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64) (Git
 	}
 
 }
-func (idx PackfileIndexV2) GetObject(r io.ReadSeeker, s Sha1) (GitObject, error) {
-	// Find the object in the table.
+
+// Find the object in the table.
+func (idx PackfileIndexV2) GetObjectMetadata(r io.ReadSeeker, s Sha1) (GitObject, error) {
 	foundIdx := -1
 	startIdx := idx.Fanout[s[0]]
 
@@ -216,14 +220,50 @@ func (idx PackfileIndexV2) GetObject(r io.ReadSeeker, s Sha1) (GitObject, error)
 
 	// Now that we've figured out where the object lives, use the packfile
 	// to get the value from the packfile.
-	return idx.getObjectAtOffset(r, offset)
+	return idx.getObjectAtOffset(r, offset, true)
+}
+func (idx PackfileIndexV2) GetObject(r io.ReadSeeker, s Sha1) (GitObject, error) {
+	foundIdx := -1
+	startIdx := idx.Fanout[s[0]]
+
+	// Packfiles are designed so that we could do a binary search here, but
+	// we don't need that optimization yet, so just do a linear search through
+	// the objects with the same first byte.
+	for i := startIdx - 1; idx.Sha1Table[i][0] == s[0]; i-- {
+		if s == idx.Sha1Table[i] {
+			foundIdx = int(i)
+			break
+		}
+	}
+	if foundIdx == -1 {
+		return nil, fmt.Errorf("Object not found")
+	}
+
+	var offset int64
+	if idx.FourByteOffsets[foundIdx]&(1<<31) != 0 {
+		// clear out the MSB to get the offset
+		eightbyteOffset := idx.FourByteOffsets[foundIdx] ^ (1 << 31)
+		offset = int64(idx.EightByteOffsets[eightbyteOffset])
+	} else {
+		offset = int64(idx.FourByteOffsets[foundIdx])
+	}
+
+	// Now that we've figured out where the object lives, use the packfile
+	// to get the value from the packfile.
+	return idx.getObjectAtOffset(r, offset, false)
 }
 
-func getPackFileObject(idx io.Reader, packfile io.ReadSeeker, s Sha1) (GitObject, error) {
+func getPackFileObject(idx io.Reader, packfile io.ReadSeeker, s Sha1, metaOnly bool) (GitObject, error) {
 	var pack PackfileIndexV2
-	binary.Read(idx, binary.BigEndian, &pack.magic)
-	binary.Read(idx, binary.BigEndian, &pack.Version)
-	binary.Read(idx, binary.BigEndian, &pack.Fanout)
+	if err := binary.Read(idx, binary.BigEndian, &pack.magic); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(idx, binary.BigEndian, &pack.Version); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(idx, binary.BigEndian, &pack.Fanout); err != nil {
+		return nil, err
+	}
 	pack.Sha1Table = make([]Sha1, pack.Fanout[255])
 	pack.CRC32 = make([]uint32, pack.Fanout[255])
 	pack.FourByteOffsets = make([]uint32, pack.Fanout[255])
@@ -232,13 +272,19 @@ func getPackFileObject(idx io.Reader, packfile io.ReadSeeker, s Sha1) (GitObject
 	// table is dynamicly sized.
 
 	for i := 0; i < len(pack.Sha1Table); i++ {
-		binary.Read(idx, binary.BigEndian, &pack.Sha1Table[i])
+		if err := binary.Read(idx, binary.BigEndian, &pack.Sha1Table[i]); err != nil {
+			return nil, err
+		}
 	}
 	for i := 0; i < len(pack.CRC32); i++ {
-		binary.Read(idx, binary.BigEndian, &pack.CRC32[i])
+		if err := binary.Read(idx, binary.BigEndian, &pack.CRC32[i]); err != nil {
+			return nil, err
+		}
 	}
 	for i := 0; i < len(pack.FourByteOffsets); i++ {
-		binary.Read(idx, binary.BigEndian, &pack.FourByteOffsets[i])
+		if err := binary.Read(idx, binary.BigEndian, &pack.FourByteOffsets[i]); err != nil {
+			return nil, err
+		}
 	}
 
 	// The number of eight byte offsets is dynamic, based on how many
@@ -250,7 +296,9 @@ func getPackFileObject(idx io.Reader, packfile io.ReadSeeker, s Sha1) (GitObject
 			pack.EightByteOffsets = append(pack.EightByteOffsets, val)
 		}
 	}
-
+	if metaOnly {
+		return pack.GetObjectMetadata(packfile, s)
+	}
 	return pack.GetObject(packfile, s)
 }
 func (idx PackfileIndexV2) GetTrailer() (Sha1, Sha1) {

--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -99,24 +99,25 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReadSeeker, offset int64, meta
 		return nil, err
 	}
 
-	t, _, ref, refoffset, _ := p.ReadHeaderSize(r)
+	t, sz, ref, refoffset, _ := p.ReadHeaderSize(r)
 	var rawdata []byte
 	if !metaOnly || t == OBJ_OFS_DELTA || t == OBJ_REF_DELTA {
 		rawdata, _ = p.ReadEntryDataStream(r)
 	}
+
 	// The way we calculate the hash changes based on if it's a delta
 	// or not.
 	switch t {
 	case OBJ_COMMIT:
-		return GitCommitObject{len(rawdata), rawdata}, nil
+		return GitCommitObject{int(sz), rawdata}, nil
 	case OBJ_TREE:
-		return GitTreeObject{len(rawdata), rawdata}, nil
+		return GitTreeObject{int(sz), rawdata}, nil
 	case OBJ_BLOB:
-		return GitBlobObject{len(rawdata), rawdata}, nil
+		return GitBlobObject{int(sz), rawdata}, nil
 	case OBJ_OFS_DELTA:
 		// Things aren't very consistent with if types are strings, types,
 		// or interfaces, making this far more difficult than it needs to be.
-		base, err := idx.getObjectAtOffset(r, offset-int64(refoffset), metaOnly)
+		base, err := idx.getObjectAtOffset(r, offset-int64(refoffset), false)
 		if err != nil {
 			return nil, err
 		}

--- a/git/objects.go
+++ b/git/objects.go
@@ -208,7 +208,7 @@ func (c *Client) GetObject(sha1 Sha1) (GitObject, error) {
 }
 
 func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
-	if gobj, ok := c.objcache[sha1]; ok {
+	if gobj, ok := c.objcache[shaRef{sha1, metaOnly}]; ok {
 		// FIXME: We should determine why this is attempting to retrieve the
 		// same things multiple times and fix the source.
 		return gobj, nil
@@ -229,7 +229,7 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 		if err != nil {
 			return nil, err
 		}
-		c.objcache[sha1] = gobj
+		c.objcache[shaRef{sha1, metaOnly}] = gobj
 		return gobj, nil
 	} else {
 		objectname := fmt.Sprintf("%s/objects/%x/%x", c.GitDir, sha1[0:1], sha1[1:])
@@ -285,7 +285,7 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 			}
 		}
 		gobj := GitBlobObject{size, content}
-		c.objcache[sha1] = gobj
+		c.objcache[shaRef{sha1, metaOnly}] = gobj
 		return gobj, nil
 	} else if strings.HasPrefix(string(b), "commit ") {
 		var size int
@@ -300,7 +300,7 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 			}
 		}
 		gobj := GitCommitObject{size, content}
-		c.objcache[sha1] = gobj
+		c.objcache[shaRef{sha1, metaOnly}] = gobj
 		return gobj, nil
 	} else if strings.HasPrefix(string(b), "tree ") {
 		var size int
@@ -315,7 +315,7 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 			}
 		}
 		gobj := GitTreeObject{size, content}
-		c.objcache[sha1] = gobj
+		c.objcache[shaRef{sha1, metaOnly}] = gobj
 		return gobj, nil
 	} else {
 		fmt.Printf("Content: %s\n", string(b))

--- a/git/objects.go
+++ b/git/objects.go
@@ -213,7 +213,6 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 		// same things multiple times and fix the source.
 		return gobj, nil
 	}
-
 	found, packfile, err := c.HaveObject(sha1)
 	if err != nil {
 		return nil, err

--- a/git/objects.go
+++ b/git/objects.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bufio"
 	"bytes"
 	"compress/zlib"
 	"errors"
@@ -31,6 +32,9 @@ func (GitBlobObject) GetType() string {
 	return "blob"
 }
 func (b GitBlobObject) GetContent() []byte {
+	if b.content == nil {
+		panic("Attempted to get content but only loaded metadata")
+	}
 	if len(b.content) != b.size {
 		panic(fmt.Sprintf("Content of blob does not match size. %d != %d", len(b.content), b.size))
 	}
@@ -50,6 +54,9 @@ type GitCommitObject struct {
 }
 
 func (c GitCommitObject) GetContent() []byte {
+	if c.content == nil {
+		panic("Attempted to get content but only loaded metadata")
+	}
 	return c.content
 }
 
@@ -84,6 +91,9 @@ type GitTreeObject struct {
 }
 
 func (t GitTreeObject) GetContent() []byte {
+	if t.content == nil {
+		panic("Attempted to get content but only loaded metadata")
+	}
 	return t.content
 }
 
@@ -140,7 +150,7 @@ func (t GitTreeObject) String() string {
 // Returns the byte array of a packed object from packfile, after
 // resolving any deltas. (packfile should be the base name with no
 // extension.)
-func (c *Client) getPackedObject(packfile File, sha1 Sha1) (GitObject, error) {
+func (c *Client) getPackedObject(packfile File, sha1 Sha1, metaOnly bool) (GitObject, error) {
 	idx, err := (packfile + ".idx").Open()
 	if err != nil {
 		return nil, err
@@ -153,7 +163,11 @@ func (c *Client) getPackedObject(packfile File, sha1 Sha1) (GitObject, error) {
 	}
 	defer data.Close()
 
-	return getPackFileObject(idx, data, sha1)
+	po, err := getPackFileObject(idx, data, sha1, metaOnly)
+	if err != nil {
+		return nil, err
+	}
+	return po, err
 }
 
 func (c *Client) GetCommitObject(commit CommitID) (GitCommitObject, error) {
@@ -164,7 +178,19 @@ func (c *Client) GetCommitObject(commit CommitID) (GitCommitObject, error) {
 	}
 	return gco, fmt.Errorf("Could not convert object %v to commit object: %v", o, err)
 }
+func (c *Client) GetObjectMetadata(sha1 Sha1) (string, uint64, error) {
+	obj, err := c.getObject(sha1, true)
+	if err != nil {
+		return "", 0, err
+	}
+	return obj.GetType(), uint64(obj.GetSize()), nil
+}
+
 func (c *Client) GetObject(sha1 Sha1) (GitObject, error) {
+	return c.getObject(sha1, false)
+}
+
+func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 	found, packfile, err := c.HaveObject(sha1)
 	if err != nil {
 		return nil, err
@@ -176,7 +202,7 @@ func (c *Client) GetObject(sha1 Sha1) (GitObject, error) {
 
 	var b []byte
 	if packfile != "" {
-		return c.getPackedObject(packfile, sha1)
+		return c.getPackedObject(packfile, sha1, metaOnly)
 	} else {
 		objectname := fmt.Sprintf("%s/objects/%x/%x", c.GitDir, sha1[0:1], sha1[1:])
 		f, err := os.Open(objectname)
@@ -188,11 +214,34 @@ func (c *Client) GetObject(sha1 Sha1) (GitObject, error) {
 		if err != nil {
 			return nil, err
 		}
-		b, err = ioutil.ReadAll(uncompressed)
-		if err != nil {
-			return nil, err
-		}
+		if metaOnly {
+			buf := bufio.NewReader(uncompressed)
+			line, err := buf.ReadBytes(0)
 
+			pieces := strings.Fields(string(bytes.TrimSuffix(line, []byte{0})))
+			if len(pieces) != 2 {
+				return nil, fmt.Errorf("Invalid object")
+			}
+			sz, err := strconv.Atoi(pieces[1])
+			if err != nil {
+				return nil, fmt.Errorf("Invalid size: %v", err)
+			}
+			switch pieces[0] {
+			case "blob":
+				return GitBlobObject{sz, nil}, nil
+			case "tree":
+				return GitTreeObject{sz, nil}, nil
+			case "commit":
+				return GitCommitObject{sz, nil}, nil
+			}
+			return nil, fmt.Errorf("Unknown object type: %v", pieces[0])
+		} else {
+			b, err = ioutil.ReadAll(uncompressed)
+
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if strings.HasPrefix(string(b), "blob ") {

--- a/git/packfile.go
+++ b/git/packfile.go
@@ -65,7 +65,9 @@ func (p PackfileHeader) ReadHeaderSize(r io.Reader) (PackEntryType, PackEntrySiz
 	// headers should be less than 32 bytes.
 	dataread := make([]byte, 0, 32)
 	for {
-		r.Read(b)
+		if _, err := r.Read(b); err != nil {
+			panic(err)
+		}
 		dataread = append(dataread, b...)
 		if i == 0 {
 			// Extract bits 2-4, which contain the type

--- a/git/revlist.go
+++ b/git/revlist.go
@@ -31,7 +31,6 @@ func RevListCallback(c *Client, opt RevListOptions, includes, excludes []Commiti
 		if _, ok := excludeList[s]; ok {
 			return nil
 		}
-		excludeList[s] = struct{}{}
 		if opt.Objects {
 			cmt := CommitID(s)
 			_, err := cmt.GetAllObjectsExcept(c, excludeList)
@@ -39,6 +38,7 @@ func RevListCallback(c *Client, opt RevListOptions, includes, excludes []Commiti
 				return err
 			}
 		}
+		excludeList[s] = struct{}{}
 		return nil
 	}
 
@@ -72,9 +72,11 @@ func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeL
 		if _, ok := excludeList[Sha1(cmt)]; ok {
 			continue
 		}
+
 		if err := callback(Sha1(cmt)); err != nil {
 			return err
 		}
+		excludeList[Sha1(cmt)] = struct{}{}
 
 		if opt.Objects {
 			objs, err := cmt.GetAllObjectsExcept(c, excludeList)
@@ -85,7 +87,7 @@ func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeL
 				if err := callback(o); err != nil {
 					return err
 				}
-				excludeList[o] = struct{}{}
+				//excludeList[o] = struct{}{}
 			}
 		}
 		parents, err := cmt.Parents(c)

--- a/git/revlist.go
+++ b/git/revlist.go
@@ -1,0 +1,100 @@
+package git
+
+import (
+	"fmt"
+	"io"
+)
+
+// List of command line options that may be passed to RevList
+type RevListOptions struct {
+	Quiet, Objects bool
+}
+
+func RevList(c *Client, opt RevListOptions, w io.Writer, includes, excludes []Commitish) ([]Sha1, error) {
+	var vals []Sha1
+	err := RevListCallback(c, opt, includes, excludes, func(s Sha1) error {
+		vals = append(vals, s)
+		if !opt.Quiet {
+			fmt.Fprintf(w, "%v\n", s)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return vals, nil
+}
+
+func RevListCallback(c *Client, opt RevListOptions, includes, excludes []Commitish, callback func(Sha1) error) error {
+	excludeList := make(map[Sha1]struct{})
+	buildExcludeList := func(s Sha1) error {
+		if _, ok := excludeList[s]; ok {
+			return nil
+		}
+		excludeList[s] = struct{}{}
+		if opt.Objects {
+			cmt := CommitID(s)
+			_, err := cmt.GetAllObjectsExcept(c, excludeList)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if len(excludes) > 0 {
+		var cIDs []CommitID = make([]CommitID, 0, len(excludes))
+		for _, e := range excludes {
+			cmt, err := e.CommitID(c)
+			if err != nil {
+				return err
+			}
+			cIDs = append(cIDs, cmt)
+		}
+		if err := revListCallback(c, opt, cIDs, excludeList, buildExcludeList); err != nil {
+			return err
+		}
+	}
+
+	cIDs := make([]CommitID, 0, len(includes))
+	for _, i := range includes {
+		cmt, err := i.CommitID(c)
+		if err != nil {
+			return err
+		}
+		cIDs = append(cIDs, cmt)
+	}
+	return revListCallback(c, opt, cIDs, excludeList, callback)
+}
+
+func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeList map[Sha1]struct{}, callback func(Sha1) error) error {
+	for _, cmt := range commits {
+		if _, ok := excludeList[Sha1(cmt)]; ok {
+			continue
+		}
+		if err := callback(Sha1(cmt)); err != nil {
+			return err
+		}
+
+		if opt.Objects {
+			objs, err := cmt.GetAllObjectsExcept(c, excludeList)
+			if err != nil {
+				return err
+			}
+			for _, o := range objs {
+				if err := callback(o); err != nil {
+					return err
+				}
+				excludeList[o] = struct{}{}
+			}
+		}
+		parents, err := cmt.Parents(c)
+		if err != nil {
+			return err
+		}
+		if err := revListCallback(c, opt, parents, excludeList, callback); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/git/revparse.go
+++ b/git/revparse.go
@@ -16,7 +16,7 @@ type ParsedRevision struct {
 
 func (pr ParsedRevision) CommitID(c *Client) (CommitID, error) {
 	if pr.Id.Type(c) != "commit" {
-		return CommitID{}, fmt.Errorf("Invalid revision commit")
+		return CommitID{}, fmt.Errorf("Invalid revision commit: %v", pr.Id)
 	}
 	return CommitID(pr.Id), nil
 }

--- a/git/sha1.go
+++ b/git/sha1.go
@@ -401,20 +401,28 @@ func NearestCommonParent(c *Client, com, other Commitish) (CommitID, error) {
 }
 
 func (c CommitID) GetAllObjects(cl *Client) ([]Sha1, error) {
+	return c.GetAllObjectsExcept(cl, nil)
+}
+
+// returns a list of all objects in c excluding those in excludeList. It also populates excludeList
+// with any objects encountered.
+func (c CommitID) GetAllObjectsExcept(cl *Client, excludeList map[Sha1]struct{}) ([]Sha1, error) {
 	var objects []Sha1
 	tree, err := c.TreeID(cl)
 	if err != nil {
 		return nil, err
 	}
 	objects = append(objects, Sha1(tree))
-	children, err := tree.GetAllObjects(cl, "", true, false)
+	children, err := tree.GetAllObjectsExcept(cl, excludeList, "", true, false)
 	if err != nil {
 		return nil, err
 	}
 	for _, s := range children {
 		objects = append(objects, s.Sha1)
 	}
+	excludeList[Sha1(c)] = struct{}{}
 	return objects, nil
+
 }
 
 // A TreeEntry represents an entry inside of a Treeish.
@@ -427,6 +435,18 @@ type TreeEntry struct {
 // into subtrees. If excludeself is true, it will *not* include it's own Sha1.
 // (Only really meaningful with recurse)
 func (t TreeID) GetAllObjects(cl *Client, prefix IndexPath, recurse, excludeself bool) (map[IndexPath]TreeEntry, error) {
+	return t.GetAllObjectsExcept(cl, nil, prefix, recurse, excludeself)
+}
+
+// GetAllObjectsExcept is like GetAllObjects, except that it excludes those objects in excludeList. It also
+// populates excludeList with any objects encountered.
+func (t TreeID) GetAllObjectsExcept(cl *Client, excludeList map[Sha1]struct{}, prefix IndexPath, recurse, excludeself bool) (map[IndexPath]TreeEntry, error) {
+	if excludeList == nil {
+		excludeList = make(map[Sha1]struct{})
+	}
+	if _, ok := excludeList[Sha1(t)]; ok {
+		return nil, nil
+	}
 	o, err := cl.GetObject(Sha1(t))
 	if err != nil {
 		return nil, err
@@ -435,6 +455,8 @@ func (t TreeID) GetAllObjects(cl *Client, prefix IndexPath, recurse, excludeself
 	if o.GetType() != "tree" {
 		return nil, fmt.Errorf("%s is not a tree object", t)
 	}
+
+	excludeList[Sha1(t)] = struct{}{}
 
 	treecontent := o.GetContent()
 	entryStart := 0
@@ -454,6 +476,7 @@ func (t TreeID) GetAllObjects(cl *Client, prefix IndexPath, recurse, excludeself
 			if err != nil {
 				return nil, err
 			}
+			excludeList[sha] = struct{}{}
 
 			// Split up the perm from the name based on the whitespace
 			split := bytes.SplitN(treecontent[entryStart:i], []byte{' '}, 2)
@@ -466,13 +489,13 @@ func (t TreeID) GetAllObjects(cl *Client, prefix IndexPath, recurse, excludeself
 				mode = ModeTree
 				if recurse {
 					childTree := TreeID(sha)
-					children, err := childTree.GetAllObjects(cl, "", recurse, excludeself)
+					children, err := childTree.GetAllObjectsExcept(cl, excludeList, "", recurse, excludeself)
 					if err != nil {
 						return nil, err
 					}
+					excludeList[sha] = struct{}{}
 					for child, childval := range children {
 						val[IndexPath(name)+"/"+child] = childval
-
 					}
 				}
 			case "100644":
@@ -493,7 +516,6 @@ func (t TreeID) GetAllObjects(cl *Client, prefix IndexPath, recurse, excludeself
 			i += 20
 			entryStart = i + 1
 		}
-
 	}
 	return val, nil
 }

--- a/git/sha1.go
+++ b/git/sha1.go
@@ -81,11 +81,11 @@ func (s Sha1) CompressedWriter(c *Client, w io.Writer) error {
 }
 
 func (s Sha1) UncompressedSize(c *Client) uint64 {
-	obj, err := c.GetObject(s)
+	_, sz, err := c.GetObjectMetadata(s)
 	if err != nil {
 		return 0
 	}
-	return uint64(obj.GetSize())
+	return sz
 }
 
 func (id Sha1) PackEntryType(c *Client) PackEntryType {
@@ -105,11 +105,12 @@ func (id Sha1) PackEntryType(c *Client) PackEntryType {
 
 // Returns the git type of the object this Sha1 represents
 func (id Sha1) Type(c *Client) string {
-	obj, err := c.GetObject(id)
+	t, _, err := c.GetObjectMetadata(id)
 	if err != nil {
+		panic(err)
 		return ""
 	}
-	return obj.GetType()
+	return t
 }
 
 // Returns all direct parents of commit c.
@@ -376,7 +377,6 @@ func (s CommitID) ancestors(c *Client) (commits []CommitID, err error) {
 	}
 
 	ancestorCache[s] = commits
-
 	return
 }
 
@@ -512,7 +512,7 @@ func (c CommitID) TreeID(cl *Client) (TreeID, error) {
 func (t TreeID) TreeID(cl *Client) (TreeID, error) {
 	// Validate that it's a tree
 	if Sha1(t).Type(cl) != "tree" {
-		return TreeID{}, fmt.Errorf("Invalid tree")
+		return TreeID{}, fmt.Errorf("Invalid tree: %v", t)
 	}
 	return t, nil
 }

--- a/main.go
+++ b/main.go
@@ -250,7 +250,10 @@ func main() {
 
 	case "rev-list":
 		subcommandUsage = "<commit>..."
-		cmd.RevList(c, args)
+		if _, err := cmd.RevList(c, args); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
 	case "hash-object":
 		subcommandUsage = "[<file>...]"
 		cmd.HashObject(c, args)

--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func main() {
 
 	case "rev-list":
 		subcommandUsage = "<commit>..."
-		if _, err := cmd.RevList(c, args); err != nil {
+		if err := cmd.RevList(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
@@ -270,7 +270,10 @@ func main() {
 		}
 	case "push":
 		subcommandUsage = "<repository>"
-		cmd.Push(c, args)
+		if err := cmd.Push(c, args); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(4)
+		}
 	case "pack-objects":
 		subcommandUsage = "<basename>"
 		cmd.PackObjects(c, os.Stdin, args)

--- a/main.go
+++ b/main.go
@@ -99,6 +99,9 @@ func main() {
 		fmt.Fprint(os.Stderr, "Could not find .git directory\n")
 		os.Exit(4)
 	}
+	if c != nil {
+		defer c.Close()
+	}
 	if *superprefix != "" {
 		c.SuperPrefix = *superprefix
 	}


### PR DESCRIPTION
Previously "dgit push" would calculate the missing objects based on the revision on the remote that matches the current branch and only that commit. It now uses the refs from all remote heads to guess which objects are missing, and as a result is able to push to new branches, not only existing ones (it may also get lucky and result in a smaller list of objects being sent with this change. Ideally it would use the pack protocol to calculate exactly what's was missing, but this gets somewhat closer.)

The option "git push --set-upstream" is also implemented in this PR, so that you don't need to manually edit the git config file to push new branches.

The end result should be that it's now possible to send GitHub PRs with dgit (if you have a way to click the "Open new pull request" button from the front end.)