### PR TITLE
Make git log subcommand use rev-list

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -12,10 +12,10 @@ import (
 
 // Since libgit is somewhat out of our control and we can't implement
 // a fmt.Stringer interface there, we use this helper.
-func printCommit(c *git.Client, cmt git.CommitID) {
+func printCommit(c *git.Client, cmt git.CommitID) error {
 	author, err := cmt.GetAuthor(c)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	fmt.Printf("commit %s\n", cmt)
 	if parents, err := cmt.Parents(c); len(parents) > 1 && err == nil {
@@ -30,39 +30,20 @@ func printCommit(c *git.Client, cmt git.CommitID) {
 	}
 	date, err := cmt.GetDate(c)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	fmt.Printf("Author: %v\nDate:   %v\n\n", author, date.Format("Mon Jan 2 15:04:05 2006 -0700"))
 	log.Printf("Commit %v\n", cmt)
 
 	msg, err := cmt.GetCommitMessage(c)
+	if err != nil {
+		return err
+	}
 	lines := strings.Split(strings.TrimSpace(msg.String()), "\n")
 	for _, l := range lines {
 		fmt.Printf("    %v\n", l)
 	}
 	fmt.Printf("\n")
-}
-
-var visited map[git.CommitID]bool
-
-func walkParents(c *git.Client, cmt git.CommitID) error {
-	if visited[cmt] {
-		return nil
-	}
-	visited[cmt] = true
-	printCommit(c, cmt)
-	parents, err := cmt.Parents(c)
-	if err != nil {
-		return err
-	}
-	for _, p := range parents {
-		if _, visited := visited[p]; visited {
-			continue
-		}
-		if err := walkParents(c, p); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -104,14 +85,8 @@ func Log(c *git.Client, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	cmt, err := commit.CommitID(c)
-	if err != nil {
-		return err
-	}
-
-	visited = make(map[git.CommitID]bool)
-
-	return walkParents(c, cmt)
+	return git.RevListCallback(c, git.RevListOptions{Quiet: true}, []git.Commitish{commit}, nil, func(s git.Sha1) error {
+		return printCommit(c, git.CommitID(s))
+	})
 
 }

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/driusan/dgit/git"
+)
+
+func BenchmarkLogHead(b *testing.B) {
+	c, err := git.NewClient("../.git", ".")
+	if err != nil {
+		panic(err)
+	}
+	for n := 0; n < b.N; n++ {
+		if err := Log(c, []string{}); err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
Slight cleanup of git log to make it use
rev-list with a callback for printing instead
of doing the same work in a different way.

Added a benchmark for good measure.