### PR TITLE
More optimization of rev-list command.

### DIFF
--- a/git/revlist.go
+++ b/git/revlist.go
@@ -87,7 +87,6 @@ func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeL
 				if err := callback(o); err != nil {
 					return err
 				}
-				//excludeList[o] = struct{}{}
 			}
 		}
 		parents, err := cmt.Parents(c)


### PR DESCRIPTION
The code was previously parsing and re-parsing the index file for each
object it was trying to retrieve from a pack, thereby defeating the
purpose of indexing it in the first place. This finally makes some
significant progress on rev-list benchmark by caching the index after
being parsed.

Before:
BenchmarkRevListHead-4                         1        4478326709 ns/op
BenchmarkRevListHeadExclude-4                  1        4360914540 ns/op
BenchmarkRevListHeadExcludeObjects-4           1        15265898270 ns/op

After:
BenchmarkRevListHead-4                      2000            797315 ns/op
BenchmarkRevListHeadExclude-4               2000            917981 ns/op
BenchmarkRevListHeadExcludeObjects-4           1        2602027452 ns/op