### PR TITLE
Add factotum support for Plan 9 and disable password echo on other

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go_import_path: github.com/driusan/dgit
 
 script:
     - GOOS=darwin go build
+    - GOOS=plan9 get get ./...
     - GOOS=plan9 go build
     - GOOS=windows go build
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go_import_path: github.com/driusan/dgit
 
 script:
     - GOOS=darwin go build
-    - GOOS=plan9 get get ./...
+    - GOOS=plan9 go get ./...
     - GOOS=plan9 go build
     - GOOS=windows go build
     - pwd

--- a/git/password_other.go
+++ b/git/password_other.go
@@ -1,0 +1,15 @@
+//+build !plan9
+package git
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func getPassword(url string) (string, error) {
+	fmt.Fprintf(os.Stderr, "Password: ")
+	pwb, err := terminal.ReadPassword(0)
+	return string(pwb), err
+}

--- a/git/password_other.go
+++ b/git/password_other.go
@@ -1,4 +1,5 @@
 //+build !plan9
+
 package git
 
 import (

--- a/git/password_plan9.go
+++ b/git/password_plan9.go
@@ -1,0 +1,19 @@
+package git
+
+import (
+	"bitbucket.org/mischief/libauth"
+	"os/user"
+)
+
+func getPassword(url string) (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return libauth.Getuserpasswd(
+		"proto=pass service=git role=client server=%s user=%s",
+		url,
+		user.Username,
+	)
+}

--- a/git/retrieve.go
+++ b/git/retrieve.go
@@ -229,7 +229,6 @@ func (s *SmartHTTPServerRetriever) getRefs(service, expectedmime string) (io.Rea
 	}
 
 	if s.username != "" || s.password != "" {
-		println("Setting password ", s.username, s.password)
 		req.SetBasicAuth(s.username, s.password)
 	}
 	resp, err := http.DefaultClient.Do(req)
@@ -260,7 +259,11 @@ func (s *SmartHTTPServerRetriever) NegotiateSendPack() ([]*Reference, error) {
 	var err error
 
 	s.username = readLine("Username: ")
-	s.password = readLine("Password: ")
+	pw, err := getPassword(s.Location)
+	if err != nil {
+		return nil, err
+	}
+	s.password = pw
 	r, err := s.getRefs("git-receive-pack", "application/x-git-receive-pack-request")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This improves the reading of passwords for git push by using factotum
on Plan 9, and without echoing to the terminal on other systems.