### PR TITLE
Add support for OpenBSD ctime/inode in index

### DIFF
--- a/git/file_ctime_other.go
+++ b/git/file_ctime_other.go
@@ -1,6 +1,7 @@
 // +build !dragonfly
 // +build !darwin
 // +build !linux
+// +build !openbsd
 
 package git
 

--- a/git/file_ctime_unix.go
+++ b/git/file_ctime_unix.go
@@ -1,4 +1,4 @@
-// +build dragonfly linux
+// +build dragonfly linux openbsd
 
 package git
 

--- a/git/file_inode_other.go
+++ b/git/file_inode_other.go
@@ -1,6 +1,7 @@
 // +build !dragonfly
 // +build !darwin
 // +build !linux
+// +build !openbsd
 
 package git
 

--- a/git/file_inode_unix.go
+++ b/git/file_inode_unix.go
@@ -1,4 +1,4 @@
-// +build dragonfly linux
+// +build dragonfly linux openbsd
 
 package git
 


### PR DESCRIPTION
This adds OpenBSD to the "unix" variant of ctime and inode which
improves the reliability of "git status". (OpenBSD is one of the
easiest OSes to install under vmx, so it makes sense to support
it to help with the development of dgit and make it easier to run
under 9front..)