### PR TITLE
Fix pushing to URLs that end in .git

### DIFF
--- a/git/retrieve.go
+++ b/git/retrieve.go
@@ -264,7 +264,7 @@ func (s *SmartHTTPServerRetriever) NegotiateSendPack() ([]*Reference, error) {
 		return nil, err
 	}
 	s.password = pw
-	r, err := s.getRefs("git-receive-pack", "application/x-git-receive-pack-request")
+	r, err := s.getRefs("git-receive-pack", "application/x-git-receive-pack-advertisement")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes the send-pack negotiation so that both URLs that end
in .git, or those that don't work. ie. https://github.com/driusan/dgit.git
now works as well as https://github.com/driusan/dgit as an origin that can
be pushed to.

Fixes #8.