### PR TITLE
Add support for reading V3 index files

### DIFF
--- a/git/expandtree.go
+++ b/git/expandtree.go
@@ -80,7 +80,7 @@ func expandGitTreeIntoIndexesRecursive(c *Client, t TreeID, prefix string, recur
 					}
 				}
 
-				newEntry.Flags = uint16(len(dirname)) & 0xFFF
+				newEntry.FixedIndexEntry.Flags = uint16(len(dirname)) & 0xFFF
 			}
 			newEntries = append(newEntries, &newEntry)
 		}


### PR DESCRIPTION
This adds support for loading version 3 index files with
files that have the extended flag set.

This is required in order to read indexes which use either the intend-to-add
flag, or the skip-worktree flag.