### PR TITLE
Small fixes

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -54,6 +54,9 @@ func Commit(c *git.Client, args []string) (string, error) {
 	flags.BoolVar(&opts.AllowEmpty, "allow-empty", false, "")
 	flags.BoolVar(&opts.AllowEmptyMessage, "allow-empty-message", false, "")
 
+	flags.BoolVar(&opts.Quiet, "quiet", false, "Suppress printing of commit id")
+	flags.BoolVar(&opts.Quiet, "q", false, "Alias of --quiet")
+
 	edit := false
 	flags.BoolVar(&edit, "edit", false, "")
 	flags.BoolVar(&edit, "e", false, "Alias for --edit")
@@ -112,6 +115,9 @@ func Commit(c *git.Client, args []string) (string, error) {
 		printNoUserMessage(committer)
 		fallthrough
 	case nil:
+		if opts.Quiet {
+			return "", nil
+		}
 		return cmt.String(), nil
 	default:
 		return "", err

--- a/cmd/updateindex.go
+++ b/cmd/updateindex.go
@@ -22,14 +22,11 @@ func parseCacheInfo(input string) (git.CacheInfo, error) {
 		ret.Mode = git.ModeExec
 	case "120000":
 		ret.Mode = git.ModeSymlink
-		//		case "160000":
-		//			ret.Mode = git.Commit
-		//	An index can't contain a commit..
-		//		case "040000", "40000":
-		//			ret.EntryMode = git.Tree
-		// an index can't contain a tree, either..
+	case "160000":
+		// A commit may be part of a tree if dealing with submodules
+		ret.Mode = git.ModeCommit
 	default:
-		return git.CacheInfo{}, fmt.Errorf("Invalid EntryMode")
+		return git.CacheInfo{}, fmt.Errorf("Invalid EntryMode: %v", pieces[0])
 	}
 
 	sha1, err := git.Sha1FromString(pieces[1])

--- a/git/revparse.go
+++ b/git/revparse.go
@@ -298,6 +298,17 @@ func RevParse(c *Client, opt RevParseOptions, args []string) (commits []ParsedRe
 					} else {
 						commits = append(commits, ParsedRevision{sha, exclude})
 					}
+				} else if strings.HasSuffix(arg, "^{tree}") {
+					tree, err := RevParseTreeish(c, &opt, strings.TrimSuffix(sha, "^{tree}"))
+					if err != nil {
+						err2 = err
+					} else {
+						treeid, err := tree.TreeID(c)
+						if err != nil {
+							err2 = err
+						}
+						commits = append(commits, ParsedRevision{Sha1(treeid), exclude})
+					}
 				} else {
 					cmt, err := RevParseCommit(c, &opt, sha)
 					if err != nil {


### PR DESCRIPTION
This does a few small fixes which, when combined with mktree, allows the setup of t1014-read-tree-confusing to run.

(The test itself doesn't pass because there is no code to do what the test is checking for after the setup yet.)