### PR TITLE
Add support for git ls-remote command and preliminary support for protocol v2

### DIFF
--- a/cmd/lsremote.go
+++ b/cmd/lsremote.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/driusan/dgit/git"
+)
+
+func LsRemote(c *git.Client, args []string) error {
+	flags := flag.NewFlagSet("ls-remote", flag.ExitOnError)
+	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
+
+	opts := git.LsRemoteOptions{}
+	flags.BoolVar(&opts.Heads, "heads", false, "Show only heads")
+	flags.BoolVar(&opts.Heads, "h", false, "Alias of -heads")
+	flags.BoolVar(&opts.Tags, "tags", false, "Show only tags")
+	flags.BoolVar(&opts.Tags, "t", false, "Alias of -tags")
+	flags.BoolVar(&opts.RefsOnly, "refs", false, "Do not show pseudo-refs or peeled tags in output")
+	flags.BoolVar(&opts.Quiet, "quiet", false, "Do not print matching refs")
+	flags.BoolVar(&opts.Quiet, "q", false, "alias of --q")
+	flags.StringVar(&opts.UploadPack, "upload-pack", "", "Specify the full path of git-upload-pack on the remote")
+	flags.BoolVar(&opts.ExitCode, "exit-code", false, "Exit with status 2 when no matching refs are found")
+	flags.BoolVar(&opts.GetURL, "get-url", false, "Expand the url without talking to the remote")
+	flags.BoolVar(&opts.SymRef, "symref", false, "Show the underlying ref when showing a symbolic ref")
+	flags.StringVar(&opts.Sort, "sort", "", "Sort based on the given key pattern")
+
+	flags.Var(newMultiStringValue(&opts.ServerOptions), "server-option", "Transmit the option when using protocol versoin 2.")
+	flags.Var(newMultiStringValue(&opts.ServerOptions), "o", "Alias of --server-option")
+
+	flags.Parse(args)
+	args = flags.Args()
+	var repo git.Remote
+	var patterns []string
+	switch len(args) {
+	case 0:
+		repo = "origin"
+	case 1:
+		repo = git.Remote(args[0])
+	default:
+		repo = git.Remote(args[0])
+		for _, ref := range args[1:] {
+			patterns = append(patterns, ref)
+		}
+	}
+	refs, err := git.LsRemote(c, opts, repo, patterns)
+	if err != nil {
+		return err
+	}
+	if opts.ExitCode && len(refs) == 0 {
+		os.Exit(2)
+	}
+	if !opts.Quiet {
+		for _, ref := range refs {
+			fmt.Println(ref)
+		}
+	}
+	return nil
+}

--- a/git/fetchpack.go
+++ b/git/fetchpack.go
@@ -1,0 +1,64 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+type FetchPackOptions struct {
+	All                            bool
+	Stdin                          io.Reader
+	StatelessRPC                   bool
+	Quiet                          bool
+	Keep                           bool
+	Thin                           bool
+	IncludeTag                     bool
+	UploadPack                     string
+	Depth                          int32
+	DeepenRelative                 bool
+	NoProgress                     bool
+	CheckSelfContainedAndConnected bool
+	Verbose                        bool
+}
+
+func FetchPack(c *Client, opts FetchPackOptions, rmt Remote, refs []Ref) error {
+	return fmt.Errorf("fetch-pack not implemented")
+}
+
+var flushPkt = errors.New("Git protocol flush packet")
+var delimPkt = errors.New("Git protocol delimiter packet")
+
+// A packProtocolReader reads from a connection using the git pack
+// protocol, decoding lines read from the connection as necessary.
+type packProtocolReader struct {
+	conn io.Reader
+}
+
+// Reads a line from the underlying connection into buf in a decoded
+// format.
+func (p packProtocolReader) Read(buf []byte) (int, error) {
+	n, err := p.conn.Read(buf[0:4])
+	if err != nil {
+		return 0, err
+	}
+	if n != 4 {
+		return 0, fmt.Errorf("Bad read for git protocol")
+	}
+	switch string(buf[0:4]) {
+	case "0000":
+		// Denotes a boundary between client/server
+		// communication
+		return 0, flushPkt
+	case "0001":
+		// Delimits a command in protocol v2
+		return 0, delimPkt
+	default:
+		size, err := strconv.ParseUint(string(buf[0:4]), 16, 0)
+		if err != nil {
+			return 0, err
+		}
+		return io.ReadFull(p.conn, buf[:size-4])
+	}
+}

--- a/git/gitconn.go
+++ b/git/gitconn.go
@@ -1,0 +1,98 @@
+package git
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+)
+
+// gitConn represents a remote which uses the git protocol
+// for transport (ie. a remote that starts with git://)
+type gitConn struct {
+	uri  *url.URL
+	conn io.ReadWriteCloser
+
+	protocolversion uint8
+	capabilities    map[string]struct{}
+
+	// References advertised upon opening the connection. Only for
+	// protocol v1
+	refs []Ref
+}
+
+func (g *gitConn) OpenConn() error {
+	host := g.uri.Hostname()
+	port := g.uri.Port()
+	if port == "" {
+		port = "9418"
+	}
+
+	// Advertisement string. Built it before trying to open the connection
+	// just in case something (somehow) goes wrong.
+	adv, err := PktLineEncodeNoNl(
+		[]byte(fmt.Sprintf(
+			"git-upload-pack %s\x00host=%s\x00\x00version=2\x00",
+			g.uri.Path,
+			host,
+		)),
+	)
+	if err != nil {
+		return err
+	}
+	conn, err := net.Dial("tcp", host+":"+port)
+	if err != nil {
+		return err
+	}
+	g.conn = conn
+
+	fmt.Fprintf(conn, "%v", adv)
+	v, cap, refs, err := parseRemoteInitialConnection(conn, false)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	g.protocolversion = v
+	g.capabilities = cap
+	g.refs = refs
+	return nil
+}
+
+func (g gitConn) Close() error {
+	fmt.Fprintf(g.conn, "0000")
+	return g.conn.Close()
+}
+
+func (g gitConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error) {
+	switch g.protocolversion {
+	case 1:
+		return getRefsV1(g.refs, opts, patterns)
+	case 2:
+		cmd, err := buildLsRefsCmdV2(opts, patterns)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(g.conn, cmd)
+		line := make([]byte, 65536)
+		var vals []Ref
+		r := packProtocolReader{g.conn}
+		for {
+			n, err := r.Read(line)
+			switch err {
+			case flushPkt:
+				return vals, nil
+			case nil: // Nothing
+			default:
+				return nil, err
+			}
+			refstr := string(line[0:n])
+			ref, err := parseLsRef(refstr)
+			if err != nil {
+				return nil, err
+			}
+			vals = append(vals, ref)
+		}
+	default:
+		return nil, fmt.Errorf("Protocol version not supported")
+	}
+}

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -1,0 +1,303 @@
+package git
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// A smartHTTPConn implements the RemoteConn interface over the smart http
+// protocol. It keeps track of state such as "what protocol version did the
+// server initially send" and "what info have we already determined from previous
+// requests"
+type smartHTTPConn struct {
+	// The giturl is the URL for this connection. It may or may not be
+	// the same as what it was initiated as, depending on whether or not
+	// ".git" had to be appended to the URL.
+	giturl string
+
+	// username/password to use over HTTP basic auth.
+	username, password string
+
+	// protocol 1 or 2
+	protocolversion uint8
+
+	// capabilities advertised in the initial connection
+	capabilities map[string]struct{}
+
+	// nil we haven't tried to open yet, true if successfully got initial
+	// git-upload-pack response, and false if there was a problem getting
+	// the upload-pack response
+	isopen *bool
+
+	// List of refs advertised at the connection opening. Only valid for
+	// protocol version 1. Version 2 uses the ls-refs command.
+	refs []Ref
+}
+
+// Opens a connection to s.giturl over the smart http protocol
+func (s *smartHTTPConn) OpenConn() error {
+	// Try directly accessing the server's URL.
+	s.giturl = strings.TrimSuffix(s.giturl, "/")
+	expectedmime := "application/x-git-upload-pack-advertisement"
+
+	// Make variable references out of true and false so we can take
+	// their address for isopen
+	var trueref bool = true
+	var falseref bool = false
+
+	req, err := http.NewRequest("GET", s.giturl+"/info/refs?service=git-upload-pack", nil)
+	if err != nil {
+		// We couldn't even try making a request, so give up early.
+		return err
+	}
+
+	// Set username and password if applicable
+	if s.username != "" || s.password != "" {
+		req.SetBasicAuth(s.username, s.password)
+	}
+	req.Header.Set("Git-Protocol", "version=2")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// If we couldn't perform the request, there's probably a
+		// network issue so give up.
+		return err
+	}
+	defer resp.Body.Close()
+	var respreader io.Reader
+	if ct := resp.Header.Get("Content-Type"); ct != expectedmime || resp.StatusCode != 200 {
+		// If the content-type was wrong, try again at "url.git"
+		log.Printf("Unexpected Content-Type for %v: got %v\n", s.giturl, ct)
+		s.giturl = s.giturl + ".git"
+		req, err = http.NewRequest("GET", s.giturl+"/info/refs?service=git-upload-pack", nil)
+		if s.username != "" || s.password != "" {
+			req.SetBasicAuth(s.username, s.password)
+		}
+		req.Header.Set("Git-Protocol", "version=2")
+		newresp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			s.isopen = &falseref
+			return fmt.Errorf("Could not connect to remote")
+		}
+		defer newresp.Body.Close()
+		if ct := newresp.Header.Get("Content-Type"); ct != expectedmime || newresp.StatusCode != 200 {
+			log.Printf("Unexpected Content-Type for %v: got %v\n", s.giturl, ct)
+			s.isopen = &falseref
+			return fmt.Errorf("Remote did not speak git protocol")
+		}
+		respreader = newresp.Body
+	} else {
+		respreader = resp.Body
+	}
+
+	version, capabilities, refs, err := parseRemoteInitialConnection(respreader)
+	if err != nil {
+		s.isopen = &falseref
+		return err
+	}
+	switch version {
+	case 1, 2:
+		s.protocolversion = version
+		s.capabilities = capabilities
+		s.refs = refs
+		s.isopen = &trueref
+		log.Printf("Using protocol version %d. Capabilities: %v\n", version, capabilities)
+		// The initial connection has been made, we now know the capabilities
+		// of the remote and can act appropriately.
+		return nil
+	default:
+		return fmt.Errorf("Unsupported protocol version")
+	}
+}
+
+func parseRemoteInitialConnection(r io.Reader) (uint8, map[string]struct{}, []Ref, error) {
+	switch line := loadLine(r); line {
+	case "version 2":
+		cap := make(map[string]struct{})
+		for line := loadLine(r); line != ""; line = loadLine(r) {
+			// Version 2 lists capabilities one per line and nothing
+			// else on the initial connection
+			cap[line] = struct{}{}
+		}
+		return 2, cap, nil, nil
+	case "# service=git-upload-pack\n":
+		// version 1 has the service advertisement, a flush line,
+		// and then a list of refs. The first ref has a list of
+		// capabilities hidden behind a nil byte.
+		if loadLine(r) != "" {
+			// Flush line
+			return 0, nil, nil, InvalidResponse
+		}
+
+		cap := make(map[string]struct{})
+		var refs []Ref
+		// parseLine populates cap if it's the first line, and
+		// refs otherwise
+		var parseLine = func(s string) (*Ref, error) {
+			log.Println(s)
+			var ret Ref
+			// The first space (ie the end of the Sha1)
+			var firstSpace int
+			// The end of the name position (either \0 or \n
+			//  can cause a name to end)
+			var nameEnd int
+			for idx, char := range s {
+				if char == ' ' && ret.Value == (Sha1{}) {
+					sha1, err := Sha1FromString(s[0:idx])
+					if err != nil {
+						return nil, err
+					}
+					ret.Value = sha1
+					firstSpace = idx
+				}
+				if char == '\000' {
+					// The first line. If it's the first 0
+					// we encountered, set name, otherwise
+					// set nameEnd to the next char for parsing
+					// the capabilities
+					nameEnd = idx + 1
+					if ret.Name == "" {
+						ret.Name = s[firstSpace:idx]
+					}
+				}
+				if char == '\n' {
+					if ret.Name == "" {
+						// Not the first line, so there
+						// was no \0
+						ret.Name = s[firstSpace:idx]
+						return &ret, nil
+					}
+					// The first line, so parse the capabilities
+					caps := strings.Split(s[nameEnd:], " ")
+					for _, c := range caps {
+						cap[c] = struct{}{}
+					}
+					return &ret, nil
+				}
+			}
+			return &ret, nil
+		}
+		for line := loadLine(r); line != ""; line = loadLine(r) {
+			ref, err := parseLine(line)
+			if err != nil {
+				return 0, nil, nil, err
+			}
+			if ref != nil {
+				refs = append(refs, *ref)
+			}
+		}
+		return 1, cap, refs, nil
+	default:
+		return 0, nil, nil, fmt.Errorf("Unhandled first response line: '%v'", line)
+	}
+}
+
+func (s smartHTTPConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error) {
+	if s.isopen == nil || *s.isopen == false {
+		return nil, fmt.Errorf("Connection is not open: %v", s)
+	}
+	var vals []Ref
+	switch s.protocolversion {
+	case 1:
+		if len(patterns) == 0 {
+			return s.refs, nil
+		}
+
+	refs:
+		for _, r := range s.refs {
+			for _, p := range patterns {
+				// FIXME: Matches is the logic used by show-ref
+				// This isn't the same as the logic for ls-remote
+				// which should honour ie. "Foo*"
+				if r.Matches(p) {
+					vals = append(vals, r)
+					continue refs
+				}
+			}
+		}
+		return vals, nil
+	case 2:
+		// Make request to $giturl/git-upload-pack
+		// payload ls-refs=	maybe symrefs, maybe peel, maybe ref-prefix depending on options\n
+		// foreach pattern 0001 pktline patternarg
+		// 0000
+		topost, err := PktLineEncode([]byte("command=ls-refs"))
+		topost += "0001"
+		if !opts.RefsOnly {
+			penc, err := PktLineEncode([]byte("peel"))
+			if err != nil {
+				return nil, err
+			}
+			topost += penc
+		}
+		if opts.SymRef {
+			penc, err := PktLineEncode([]byte("symrefs"))
+			if err != nil {
+				return nil, err
+			}
+			topost += penc
+		}
+		if len(patterns) == 0 {
+			if opts.Heads {
+				penc, err := PktLineEncode([]byte("ref-prefix refs/heads"))
+				if err != nil {
+					return nil, err
+				}
+				topost += penc
+
+			}
+			if opts.Tags {
+				penc, err := PktLineEncode([]byte("ref-prefix refs/tags"))
+				if err != nil {
+					return nil, err
+				}
+				topost += penc
+
+			}
+		} else {
+			// These appear to be the prefixes git uses with
+			// tracing turned on. They don't seem to change
+			// regardless of the command line options.
+			prefixes := []string{"", "refs/", "refs/heads/", "refs/tags/", "refs/remotes/"}
+			// FIXME: Do better
+			for _, p := range patterns {
+				for _, prefix := range prefixes {
+					penc, err := PktLineEncode([]byte("ref-prefix " + prefix + p))
+					if err != nil {
+						return nil, err
+					}
+					topost += penc
+				}
+			}
+		}
+
+		topost += "0000"
+		if err != nil {
+			return nil, err
+		}
+		r, err := http.NewRequest("POST", s.giturl+"/git-upload-pack", strings.NewReader(topost.String()))
+		r.Header.Set("User-Agent", "dgit/0.0.2")
+		r.Header.Set("Git-Protocol", "version=2")
+		r.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+		r.ContentLength = int64(len([]byte(topost)))
+		resp, err := http.DefaultClient.Do(r)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		for line := loadLine(resp.Body); line != ""; line = loadLine(resp.Body) {
+			sha1, err := Sha1FromString(line[0:40])
+			if err != nil {
+				return nil, err
+			}
+			name := line[41:]
+			vals = append(vals, Ref{Name: name, Value: sha1})
+		}
+		return vals, nil
+
+	default:
+		return nil, fmt.Errorf("Unsupported protocol version: %v", s.protocolversion)
+	}
+}

--- a/git/lsremote.go
+++ b/git/lsremote.go
@@ -22,5 +22,6 @@ func LsRemote(c *Client, opts LsRemoteOptions, r Remote, patterns []string) ([]R
 	if err := remoteconn.OpenConn(); err != nil {
 		return nil, err
 	}
+	defer remoteconn.Close()
 	return remoteconn.GetRefs(opts, patterns)
 }

--- a/git/lsremote.go
+++ b/git/lsremote.go
@@ -1,0 +1,26 @@
+package git
+
+import ()
+
+type LsRemoteOptions struct {
+	Heads, Tags   bool
+	RefsOnly      bool
+	Quiet         bool
+	UploadPack    string
+	ExitCode      bool
+	GetURL        bool
+	SymRef        bool
+	Sort          string
+	ServerOptions []string
+}
+
+func LsRemote(c *Client, opts LsRemoteOptions, r Remote, patterns []string) ([]Ref, error) {
+	remoteconn, err := NewRemoteConn(c, r)
+	if err != nil {
+		return nil, err
+	}
+	if err := remoteconn.OpenConn(); err != nil {
+		return nil, err
+	}
+	return remoteconn.GetRefs(opts, patterns)
+}

--- a/git/lsremote.go
+++ b/git/lsremote.go
@@ -19,6 +19,12 @@ func LsRemote(c *Client, opts LsRemoteOptions, r Remote, patterns []string) ([]R
 	if err != nil {
 		return nil, err
 	}
+	switch con := remoteconn.(type) {
+	case *sshConn:
+		if opts.UploadPack != "" {
+			con.uploadpack = opts.UploadPack
+		}
+	}
 	if err := remoteconn.OpenConn(); err != nil {
 		return nil, err
 	}

--- a/git/remote.go
+++ b/git/remote.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Remote string
+
+func (r Remote) RemoteURL(c *Client) (string, error) {
+	config, err := LoadLocalConfig(c)
+	if err != nil {
+		return "", err
+	}
+	if strings.Index(r.String(), "://") != -1 {
+		// It's already a URL
+		return string(r), nil
+	}
+	// It's a remote name, look it up in the config.
+	cfg, _ := config.GetConfig(fmt.Sprintf("remote.%v.url", r))
+	if cfg == "" {
+		return "", fmt.Errorf("Unknown remote")
+	}
+	return cfg, nil
+}
+
+func (r Remote) String() string {
+	return string(r)
+}
+
+func (r Remote) IsStateless(c *Client) (bool, error) {
+	url, err := r.RemoteURL(c)
+	if err != nil {
+		return false, err
+	}
+	url = strings.ToLower(url)
+	return strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://"), nil
+}
+
+// A RemoteConn represends a connection to a remote which communicates
+// with the remote.
+type RemoteConn interface {
+	// Opens a connection to the remote. This requires at least one round
+	// trip to the service and may mutate the state of this RemoteConn.
+	//
+	// After calling this, the RemoteConn should be in a useable state.
+	OpenConn() error
+
+	// Gets a list of references on the remote. If patterns is specified,
+	// restrict to refs which match the pattern. If not, return all
+	// refs
+	GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error)
+}
+
+func NewRemoteConn(c *Client, r Remote) (RemoteConn, error) {
+	if sl, err := r.IsStateless(c); err == nil && sl {
+		url, err := r.RemoteURL(c)
+		if err != nil {
+			return nil, err
+		}
+		conn := &smartHTTPConn{
+			giturl: url,
+		}
+		return conn, nil
+	}
+	return nil, fmt.Errorf("Unsupported remote type for: %v", r)
+}

--- a/git/remote.go
+++ b/git/remote.go
@@ -76,6 +76,8 @@ func NewRemoteConn(c *Client, r Remote) (RemoteConn, error) {
 			uri: uri,
 		}
 		return conn, nil
+	case "ssh":
+		return &sshConn{uploadpack: "git-upload-pack", uri: uri}, nil
 	default:
 		return nil, fmt.Errorf("Unsupported remote type for: %v", r)
 	}

--- a/git/retrieve.go
+++ b/git/retrieve.go
@@ -22,6 +22,12 @@ func PktLineEncode(line []byte) (PktLine, error) {
 	return PktLine(fmt.Sprintf("%.4x%s\n", len(line)+5, line)), nil
 }
 
+func PktLineEncodeNoNl(line []byte) (PktLine, error) {
+	if len(line) > 65535 {
+		return "", fmt.Errorf("Line too long to encode in PktLine format")
+	}
+	return PktLine(fmt.Sprintf("%.4x%s", len(line)+4, line)), nil
+}
 func (p PktLine) String() string {
 	return string(p)
 }

--- a/git/sshconn.go
+++ b/git/sshconn.go
@@ -1,0 +1,180 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/user"
+	//	"net"
+	"crypto"
+	_ "crypto/sha1"
+	"net/url"
+
+	"bitbucket.org/mischief/libauth"
+	"golang.org/x/crypto/ssh"
+)
+
+// an sshConn represents a remote which uses ssh
+// for transport (ie. a remote that starts with ssh://)
+type sshConn struct {
+	// name of the remote upload pack command
+	uploadpack string
+	uri        *url.URL
+
+	session *ssh.Session
+
+	protocolversion uint8
+	capabilities    map[string]struct{}
+
+	// References advertised upon opening the connection. Only for
+	// protocol v1
+	refs []Ref
+
+	stdin  io.Reader
+	stdout io.Writer
+}
+
+func (s *sshConn) OpenConn() error {
+	host := s.uri.Hostname()
+	port := s.uri.Port()
+	if port == "" {
+		port = "22"
+	}
+	log.Println("Opening ssh connection to", host, " port", port)
+
+	var username string
+	if s.uri.User != nil {
+		username = s.uri.User.Username()
+	} else {
+		u, err := user.Current()
+		if err != nil {
+			return err
+		}
+		username = u.Username
+	}
+	log.Println("Using username", username)
+	config := &ssh.ClientConfig{
+		User: username,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeysCallback(getSigners),
+		},
+		// FIXME: This should parse the OS appropriate host key digests
+		// (ie $home/lib/sshthumbs on Plan9, $HOME/.ssh/known_hosts on
+		// other platforms)
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	conn, err := ssh.Dial("tcp", host+":"+port, config)
+	if err != nil {
+		return err
+	}
+	session, err := conn.NewSession()
+	if err != nil {
+		return err
+	}
+	session.Stderr = os.Stderr
+	s.stdin, session.Stdout = io.Pipe()
+	session.Stdin, s.stdout = io.Pipe()
+	// We don't check error on setenv because if it failed we'll just fall
+	// back on protocol v1
+	session.Setenv("GIT_PROTOCOL", "version=2")
+	s.session = session
+
+	if err := session.Start(s.uploadpack + " " + s.uri.Path); err != nil {
+		return err
+	}
+	v, cap, refs, err := parseRemoteInitialConnection(s.stdin, false)
+	if err != nil {
+		session.Close()
+		return err
+	}
+	s.protocolversion = v
+	s.capabilities = cap
+	s.refs = refs
+	return nil
+}
+
+func (s sshConn) Close() error {
+	fmt.Fprintf(s.stdout, "0000")
+	return s.session.Close()
+}
+
+func (s sshConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error) {
+	switch s.protocolversion {
+	case 1:
+		return getRefsV1(s.refs, opts, patterns)
+	case 2:
+		cmd, err := buildLsRefsCmdV2(opts, patterns)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(s.stdout, cmd)
+		line := make([]byte, 65536)
+		var vals []Ref
+		r := packProtocolReader{s.stdin}
+		for {
+			n, err := r.Read(line)
+			switch err {
+			case flushPkt:
+				return vals, nil
+			case nil: // Nothing
+			default:
+				return nil, err
+			}
+			refstr := string(line[0:n])
+			ref, err := parseLsRef(refstr)
+			if err != nil {
+				return nil, err
+			}
+			vals = append(vals, ref)
+		}
+	default:
+		return nil, fmt.Errorf("Protocol version not supported")
+	}
+}
+
+// from mischief's scpu, get a list of signers
+func getSigners() ([]ssh.Signer, error) {
+	// FIXME: Don't assume Plan 9/factotum is present, look into ~/.ssh
+	// on other platforms.
+	k, err := libauth.Listkeys()
+	if err != nil {
+		// if libauth returned an error, it just means factotum isn't
+		// present
+		return nil, nil
+	}
+	signers := make([]ssh.Signer, len(k))
+	for i, key := range k {
+		skey, err := ssh.NewPublicKey(&key)
+		if err != nil {
+			return nil, err
+		}
+		// FIXME: Don't hardcode Sha1
+		signers[i] = keySigner{skey, crypto.SHA1}
+	}
+	return signers, nil
+}
+
+// Implements ssh.PublicKeys interface (initial based on mischief's scpu,
+// but modified to accept more key types)
+type keySigner struct {
+	key  ssh.PublicKey
+	hash crypto.Hash
+}
+
+func (s keySigner) PublicKey() ssh.PublicKey {
+	return s.key
+}
+
+func (s keySigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	h := s.hash.New()
+	h.Write(data)
+	digest := h.Sum(nil)
+
+	sig, err := libauth.RsaSign(digest)
+	if err != nil {
+		return nil, err
+	}
+	return &ssh.Signature{Format: "ssh-rsa", Blob: sig}, nil
+}

--- a/git/sshconn.go
+++ b/git/sshconn.go
@@ -1,15 +1,12 @@
 package git
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/user"
 	//	"net"
-	"crypto"
-	_ "crypto/sha1"
 	"net/url"
 
 	"bitbucket.org/mischief/libauth"
@@ -136,7 +133,7 @@ func (s sshConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error)
 
 // from mischief's scpu, get a list of signers
 func getSigners() ([]ssh.Signer, error) {
-	// FIXME: Don't assume Plan 9/factotum is present, look into ~/.ssh
+	// FIXME: Don't assume Plan 9/factotum is present, look into ~/.ssh/
 	// on other platforms.
 	k, err := libauth.Listkeys()
 	if err != nil {
@@ -146,35 +143,11 @@ func getSigners() ([]ssh.Signer, error) {
 	}
 	signers := make([]ssh.Signer, len(k))
 	for i, key := range k {
-		skey, err := ssh.NewPublicKey(&key)
+		s, err := ssh.NewSignerFromKey(&key)
 		if err != nil {
 			return nil, err
 		}
-		// FIXME: Don't hardcode Sha1
-		signers[i] = keySigner{skey, crypto.SHA1}
+		signers[i] = s
 	}
 	return signers, nil
-}
-
-// Implements ssh.PublicKeys interface (initial based on mischief's scpu,
-// but modified to accept more key types)
-type keySigner struct {
-	key  ssh.PublicKey
-	hash crypto.Hash
-}
-
-func (s keySigner) PublicKey() ssh.PublicKey {
-	return s.key
-}
-
-func (s keySigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
-	h := s.hash.New()
-	h.Write(data)
-	digest := h.Sum(nil)
-
-	sig, err := libauth.RsaSign(digest)
-	if err != nil {
-		return nil, err
-	}
-	return &ssh.Signature{Format: "ssh-rsa", Blob: sig}, nil
 }

--- a/main.go
+++ b/main.go
@@ -397,6 +397,12 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(4)
 		}
+	case "ls-remote":
+		subcommandUsage = "[repo [<patterns>..]]"
+		if err := cmd.LsRemote(c, args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	case "clean":
 		if err := cmd.Clean(c, args); err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This adds the git ls-remote command, and does it in a way that should be easier
to re-use with other non-http protocols eventually. It also adds support for the
git v2 protocol (but only in ls-remote) and eventually expand for proper fetch-pack
support, rather than the SmartHttpReceiver hack that currently exists.

The existing code is mostly untouched in order to not break things that are
currently working until the re-factoring is complete.