### PR TITLE
update clone to use fetch-pack plumbing

### DIFF
--- a/git/clone.go
+++ b/git/clone.go
@@ -89,7 +89,7 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 			// FIXME: This should have been done by GetRefs()
 			continue
 		}
-		refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/" + org + "/", 1)
+		refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/"+org+"/", 1)
 		f := c.GitDir.File(File(refname))
 		if err := f.Create(); err != nil {
 			return err

--- a/git/clone.go
+++ b/git/clone.go
@@ -77,10 +77,10 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 		org = "origin"
 	}
 	config.SetConfig(fmt.Sprintf("remote.%v.url", org), rmt.String())
-	config.SetConfig(fmt.Sprintf("remote.%v.remote", br), org)
+	config.SetConfig(fmt.Sprintf("branch.%v.remote", br), org)
 	// This should be smarter and get the HEAD symref from the connection.
 	// It isn't necessarily named refs/heads/master
-	config.SetConfig(fmt.Sprintf("remote.%v.merge", br), "refs/heads/master")
+	config.SetConfig(fmt.Sprintf("branch.%v.merge", br), "refs/heads/master")
 	if err := config.WriteConfig(); err != nil {
 		return err
 	}
@@ -89,8 +89,8 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 			// FIXME: This should have been done by GetRefs()
 			continue
 		}
-		brname := strings.TrimPrefix(ref.Name, "refs/heads/")
-		f := c.GitDir.File(File("refs/remotes/" + org + "/" + brname))
+		refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/" + org + "/", 1)
+		f := c.GitDir.File(File(refname))
 		if err := f.Create(); err != nil {
 			return err
 		}

--- a/git/clone.go
+++ b/git/clone.go
@@ -1,0 +1,137 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CloneOptions struct {
+	InitOptions
+	FetchPackOptions
+	Local                      bool
+	NoHardLinks                bool
+	Reference, ReferenceIfAble bool
+	Dissociate                 bool
+	Progress                   bool
+	NoCheckout                 bool
+	Mirror                     bool
+	// use name instead of origin as upstream remote.
+	Origin string
+	// Use branch instead of HEAD as default branch to checkout
+	Branch string
+	// Set configs in the newly created repository's config.
+	Configs map[string]string
+
+	// Only clone a single branch (either HEAD or Branch option)
+	SingleBranch bool
+
+	NoTags            bool
+	RecurseSubmodules bool
+	ShallowSubmodules bool
+	Jobs              int
+}
+
+// Clones a new repository from rmt into the directory dst, which must
+// not already exist.
+func Clone(opts CloneOptions, rmt Remote, dst File) error {
+	// This basically does the following:
+	// 1. Verify preconditions
+	// 2. Init
+	// 3. Fetch-pack --all
+	// 4. Set up some default config variables
+	// 5. UpdateRef master
+	// 6. Reset --hard
+
+	if dst.Exists() {
+		return fmt.Errorf("Directory %v already exists, can not clone.\n", dst)
+	}
+	c, err := Init(nil, opts.InitOptions, dst.String())
+	if err != nil {
+		return err
+	}
+
+	opts.FetchPackOptions.All = true
+	opts.FetchPackOptions.Verbose = true
+
+	conn, err := NewRemoteConn(c, rmt)
+	if err != nil {
+		return err
+	}
+	if err := conn.OpenConn(); err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	refs, err := fetchPackDone(c, opts.FetchPackOptions, conn, nil, nil)
+	if err != nil {
+		return err
+	}
+	config, err := LoadLocalConfig(c)
+	config.SetConfig("remote.origin.url", rmt.String())
+	br := opts.Branch
+	if br == "" {
+		br = "master"
+	}
+	org := opts.Origin
+	if opts.Origin == "" {
+		org = "origin"
+	}
+	config.SetConfig(fmt.Sprintf("remote.%v.url", org), rmt.String())
+	config.SetConfig(fmt.Sprintf("remote.%v.remote", br), org)
+	// This should be smarter and get the HEAD symref from the connection.
+	// It isn't necessarily named refs/heads/master
+	config.SetConfig(fmt.Sprintf("remote.%v.merge", br), "refs/heads/master")
+	if err := config.WriteConfig(); err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		if !strings.HasPrefix(ref.Name, "refs/heads/") {
+			// FIXME: This should have been done by GetRefs()
+			continue
+		}
+		brname := strings.TrimPrefix(ref.Name, "refs/heads/")
+		f := c.GitDir.File(File("refs/remotes/" + org + "/" + brname))
+		if err := f.Create(); err != nil {
+			return err
+		}
+		if err := f.Append(fmt.Sprintf("%v\n", ref.Value)); err != nil {
+			return err
+		}
+	}
+	// Now that we've populated all the remote names, we need to checkout
+	// the branch.
+	cmtish, err := RevParseCommitish(c, &RevParseOptions{}, org+"/"+br)
+	if err != nil {
+		return err
+	}
+	cmt, err := cmtish.CommitID(c)
+	if err != nil {
+		return err
+	}
+	// Update the master branch to point to the same commit as origin/master
+	if err := UpdateRefSpec(
+		c,
+		UpdateRefOptions{CreateReflog: true, OldValue: CommitID{}},
+		RefSpec("refs/heads/master"),
+		cmt,
+		"clone: "+rmt.String(),
+	); err != nil {
+		return err
+	}
+
+	reflog, err := c.GitDir.ReadFile("logs/refs/heads/master")
+	if err != nil {
+		return err
+	}
+	// HEAD is already pointing to refs/heads/master from init, but the
+	// logs/HEAD reflog isn't created yet. We cheat by just copying the
+	// one created by UpdateRefSpec above.
+	if err := c.GitDir.WriteFile("logs/HEAD", reflog, 0755); err != nil {
+		return err
+	}
+
+	// Finally, checkout the files. Since it's an initial clone, we just
+	// do a hard reset and don't try to be intelligent about what readtree
+	// does.
+	return Reset(c, ResetOptions{Hard: true}, nil)
+}

--- a/git/fetchpack.go
+++ b/git/fetchpack.go
@@ -313,7 +313,6 @@ func (p packProtocolReader) Read(buf []byte) (int, error) {
 			}
 			switch buf[0] {
 			case sidebandDataChannel:
-				fmt.Printf("Data")
 				return io.ReadFull(p.conn, buf[:size-5])
 			case sidebandChannel:
 				n, err := io.ReadFull(p.conn, buf[:size-5])
@@ -325,7 +324,6 @@ func (p packProtocolReader) Read(buf []byte) (int, error) {
 				}
 				goto sidebandRead
 			case sidebandErrChannel:
-				fmt.Printf("err")
 				n, err := io.ReadFull(p.conn, buf[:size-5])
 				if err != nil {
 					return n, err

--- a/git/gitconn.go
+++ b/git/gitconn.go
@@ -46,12 +46,12 @@ func (g *gitConn) OpenConn() error {
 	return nil
 }
 
-func (g gitConn) Close() error {
+func (g *gitConn) Close() error {
 	g.Flush()
 	return g.conn.Close()
 }
 
-func (g gitConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error) {
+func (g *gitConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, error) {
 	switch g.protocolversion {
 	case 1:
 		return getRefsV1(g.refs, opts, patterns)
@@ -89,24 +89,23 @@ func (g gitConn) SetUploadPack(up string) error {
 	return nil
 }
 
-func (g gitConn) Write(data []byte) (int, error) {
+func (g *gitConn) Write(data []byte) (int, error) {
 	l, err := PktLineEncodeNoNl(data)
 	if err != nil {
 		return 0, err
 	}
 	fmt.Fprintf(g.conn, "%s", l)
-	fmt.Printf("%s", l)
 	// We lie about how much data was written since
 	// we wrote more than asked.
 	return len(data), nil
 }
 
-func (g gitConn) Flush() error {
+func (g *gitConn) Flush() error {
 	fmt.Fprintf(g.conn, "0000")
 	return nil
 }
 
-func (g gitConn) Delim() error {
+func (g *gitConn) Delim() error {
 	fmt.Fprintf(g.conn, "0001")
 	return nil
 }

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -172,14 +172,14 @@ func parseRemoteInitialConnection(r io.Reader, stateless bool) (uint8, map[strin
 					// the capabilities
 					nameEnd = idx + 1
 					if ret.Name == "" {
-						ret.Name = s[firstSpace:idx]
+						ret.Name = s[firstSpace+1 : idx]
 					}
 				}
 				if char == '\n' {
 					if ret.Name == "" {
 						// Not the first line, so there
 						// was no \0
-						ret.Name = s[firstSpace:idx]
+						ret.Name = s[firstSpace+1 : idx]
 						return &ret, nil
 					}
 					// The first line, so parse the capabilities
@@ -332,22 +332,14 @@ func (s *smartHTTPConn) sendRequest(expectedmime string) error {
 	s.packProtocolReader.conn = s.lastresp
 	return nil
 }
-func (s smartHTTPConn) Read(buf []byte) (int, error) {
+func (s *smartHTTPConn) Read(buf []byte) (int, error) {
 	if s.isopen == nil || *s.isopen == false {
 		return 0, fmt.Errorf("Connection not open")
 	}
 	if s.lastresp == nil {
 		return 0, fmt.Errorf("Can not read until after first Flush() call")
 	}
-	n, err := s.sharedRemoteConn.packProtocolReader.Read(buf)
-	/*
-		if err == io.EOF {
-			// The EOF comes from the request, but we want the caller to
-			// think the connection is fully duplexed
-			return n, nil
-		}
-	*/
-	return n, err
+	return s.sharedRemoteConn.packProtocolReader.Read(buf)
 }
 
 func getRefsV1(refs []Ref, opts LsRemoteOptions, patterns []string) ([]Ref, error) {


### PR DESCRIPTION
Updates clone to use fetch-pack, rather than the old HTTP hack. This
means that could should now support all of the main git transport mechanisms.

(Pushing, fetching (and therefore pulling) over non-http is still missing.)