### PR TITLE
Add basic support for ssh on non-Plan9 platforms

### DIFF
--- a/git/ssh_other.go
+++ b/git/ssh_other.go
@@ -1,0 +1,18 @@
+// +build !plan9
+// +build !dragonfly
+// +build !openbsd
+// +build !darwin
+// +build !freebsd
+// +build !netbsd
+// +build !solaris
+
+package git
+
+import (
+	"golang.org/x/crypto/ssh"
+)
+
+func getSigners() ([]ssh.Signer, error) {
+	// By default, assume no keys
+	return nil, nil
+}

--- a/git/ssh_plan9.go
+++ b/git/ssh_plan9.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"crypto"
+	_ "crypto/sha1"
+	"io"
+
+	"bitbucket.org/mischief/libauth"
+	"golang.org/x/crypto/ssh"
+)
+
+// from mischief's scpu, get a list of signers
+func getSigners() ([]ssh.Signer, error) {
+	// FIXME: Don't assume Plan 9/factotum is present, look into ~/.ssh
+	// on other platforms.
+	k, err := libauth.Listkeys()
+	if err != nil {
+		// if libauth returned an error, it just means factotum isn't
+		// present
+		return nil, nil
+	}
+	signers := make([]ssh.Signer, len(k))
+	for i, key := range k {
+		skey, err := ssh.NewPublicKey(&key)
+		if err != nil {
+			return nil, err
+		}
+		// FIXME: Don't hardcode Sha1
+		signers[i] = keySigner{skey, crypto.SHA1}
+	}
+	return signers, nil
+}
+
+// Implements ssh.PublicKeys interface (initially based on mischief's scpu,
+// but modified to accept more key types)
+//
+// This is necessary because we don't (necessarily) have access to the private
+// key (it may be in factotum) and not exposed from libauth, so we need to be
+// able to sign using libauth.RsaSign
+type keySigner struct {
+	key  ssh.PublicKey
+	hash crypto.Hash
+}
+
+func (s keySigner) PublicKey() ssh.PublicKey {
+	return s.key
+}
+
+func (s keySigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	h := s.hash.New()
+	h.Write(data)
+	digest := h.Sum(nil)
+
+	sig, err := libauth.RsaSign(digest)
+	if err != nil {
+		return nil, err
+	}
+	return &ssh.Signature{Format: "ssh-rsa", Blob: sig}, nil
+}

--- a/git/ssh_unix.go
+++ b/git/ssh_unix.go
@@ -1,0 +1,26 @@
+// +build dragonfly openbsd darwin freebsd netbsd solaris
+
+package git
+
+import (
+	"golang.org/x/crypto/ssh"
+	"io/ioutil"
+	"os/user"
+)
+
+func getSigners() ([]ssh.Signer, error) {
+	user, err := user.Current()
+	if err != nil {
+		//
+		return nil, nil
+	}
+	f, err := ioutil.ReadFile(user.HomeDir + "/.ssh/id_rsa")
+	if err != nil {
+		return nil, nil
+	}
+	key, err := ssh.ParsePrivateKey(f)
+	if err != nil {
+		return nil, err
+	}
+	return []ssh.Signer{key}, nil
+}

--- a/git/sshconn.go
+++ b/git/sshconn.go
@@ -1,15 +1,12 @@
 package git
 
 import (
-	"crypto"
-	_ "crypto/sha1"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/user"
 
-	"bitbucket.org/mischief/libauth"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -150,55 +147,6 @@ func (s sshConn) Write(data []byte) (int, error) {
 	}
 	fmt.Fprintf(s.stdout, "%s", l)
 	return len(data), nil
-}
-
-// from mischief's scpu, get a list of signers
-func getSigners() ([]ssh.Signer, error) {
-	// FIXME: Don't assume Plan 9/factotum is present, look into ~/.ssh
-	// on other platforms.
-	k, err := libauth.Listkeys()
-	if err != nil {
-		// if libauth returned an error, it just means factotum isn't
-		// present
-		return nil, nil
-	}
-	signers := make([]ssh.Signer, len(k))
-	for i, key := range k {
-		skey, err := ssh.NewPublicKey(&key)
-		if err != nil {
-			return nil, err
-		}
-		// FIXME: Don't hardcode Sha1
-		signers[i] = keySigner{skey, crypto.SHA1}
-	}
-	return signers, nil
-}
-
-// Implements ssh.PublicKeys interface (initially based on mischief's scpu,
-// but modified to accept more key types)
-//
-// This is necessary because we don't (necessarily) have access to the private
-// key (it may be in factotum) and not exposed from libauth, so we need to be
-// able to sign using libauth.RsaSign
-type keySigner struct {
-	key  ssh.PublicKey
-	hash crypto.Hash
-}
-
-func (s keySigner) PublicKey() ssh.PublicKey {
-	return s.key
-}
-
-func (s keySigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
-	h := s.hash.New()
-	h.Write(data)
-	digest := h.Sum(nil)
-
-	sig, err := libauth.RsaSign(digest)
-	if err != nil {
-		return nil, err
-	}
-	return &ssh.Signature{Format: "ssh-rsa", Blob: sig}, nil
 }
 
 // this should be overridden for various platforms. Plan9/9front should parse


### PR DESCRIPTION
This adds basic support for ssh transport on platforms other than Plan 9.

It isn't very intelligent, it only looks for ~/.ssh/id_rsa for the private
key and if it finds it, uses it.