### PR TITLE
Make fetch-pack include support for "have" lines and use for fetching

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -32,11 +32,11 @@ func Fetch(c *git.Client, args []string) error {
 	addSharedFetchFlags(flags, &opts)
 	flags.Parse(args)
 
-	var repository string
+	var repository git.Remote
 	if flags.NArg() < 1 {
 		repository = "origin" // FIXME origin is the default unless the current branch unless there is an upstream branch configured for the current branch
 	} else if flags.NArg() == 1 {
-		repository = flags.Arg(0)
+		repository = git.Remote(flags.Arg(0))
 	} else {
 		fmt.Fprintf(os.Stderr, "Group and multiple repositories is not currently implemented\n")
 		flags.Usage()

--- a/cmd/fetchpack.go
+++ b/cmd/fetchpack.go
@@ -37,5 +37,6 @@ func FetchPack(c *git.Client, args []string) error {
 	for _, name := range args[1:] {
 		wants = append(wants, git.Refname(name))
 	}
-	return git.FetchPack(c, opts, rmt, wants, nil)
+	_, err := git.FetchPack(c, opts, rmt, wants)
+	return err
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -22,7 +22,7 @@ func Pull(c *git.Client, args []string) error {
 	addSharedMergeFlags(flags, &opts.MergeOptions)
 	flags.Parse(args)
 
-	var repository string
+	var repository git.Remote
 	var remotebranches []string
 	config, err := git.LoadLocalConfig(c)
 	if err != nil {
@@ -33,17 +33,18 @@ func Pull(c *git.Client, args []string) error {
 		// TODO simplistic, probably won't work in all cases
 		// Instead the branch information should be retrieved from the merge config
 		headbranch := c.GetHeadBranch().BranchName()
-		repository, _ = config.GetConfig("branch." + headbranch + ".remote")
+		r, _ := config.GetConfig("branch." + headbranch + ".remote")
+		repository = git.Remote(r)
 		//mergeremote, _ := config.GetConfig("branch." + head + ".merge")
 		remotebranches = []string{fmt.Sprintf("%s/%s", repository, headbranch)}
 	} else if flags.NArg() == 1 {
-		repository = flags.Arg(0)
+		repository = git.Remote(flags.Arg(0))
 		// Instead the branch information should be retrieved from the merge config
 		headbranch := c.GetHeadBranch().BranchName()
 		//mergeremote, _ := config.GetConfig("branch." + headbranch + ".merge")
 		remotebranches = []string{fmt.Sprintf("%s/%s", repository, headbranch)}
 	} else if flags.NArg() >= 2 {
-		repository = flag.Arg(0)
+		repository = git.Remote(flag.Arg(0))
 		remotebranches = flag.Args()[1:]
 	} else {
 		flags.Usage()

--- a/git/clone.go
+++ b/git/clone.go
@@ -53,16 +53,7 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 	opts.FetchPackOptions.All = true
 	opts.FetchPackOptions.Verbose = true
 
-	conn, err := NewRemoteConn(c, rmt)
-	if err != nil {
-		return err
-	}
-	if err := conn.OpenConn(); err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	refs, err := fetchPackDone(c, opts.FetchPackOptions, conn, nil, nil)
+	refs, err := FetchPack(c, opts.FetchPackOptions, rmt, nil)
 	if err != nil {
 		return err
 	}

--- a/git/fetch.go
+++ b/git/fetch.go
@@ -29,7 +29,7 @@ func Fetch(c *Client, opts FetchOptions, rmt Remote) error {
 				fmt.Printf("Creating %s with %s\n", refloc, ref.Value)
 				ioutil.WriteFile(
 					refloc,
-					[]byte(ref.Value[:]),
+					[]byte(ref.Value.String() + "\n"),
 					0644,
 				)
 			}

--- a/git/fetch.go
+++ b/git/fetch.go
@@ -29,7 +29,7 @@ func Fetch(c *Client, opts FetchOptions, rmt Remote) error {
 				fmt.Printf("Creating %s with %s\n", refloc, ref.Value)
 				ioutil.WriteFile(
 					refloc,
-					[]byte(ref.Value.String() + "\n"),
+					[]byte(ref.Value.String()+"\n"),
 					0644,
 				)
 			}

--- a/git/fetch.go
+++ b/git/fetch.go
@@ -8,52 +8,28 @@ import (
 )
 
 type FetchOptions struct {
+	FetchPackOptions
 }
 
-func Fetch(c *Client, opts FetchOptions, repository string) error {
-	config, err := LoadLocalConfig(c)
-	if err != nil {
-		panic(err)
-	}
-
-	repoid, _ := config.GetConfig("remote." + repository + ".url")
-
-	var ups Uploadpack
-	if strings.HasPrefix(repoid, "http://") || strings.HasPrefix(repoid, "https://") {
-		ups = &SmartHTTPServerRetriever{Location: repoid,
-			C: c,
-		}
-	} else {
-		return fmt.Errorf("Unknown protocol %s", repoid)
-	}
-
-	refs, pack, err := ups.NegotiatePack()
-	switch err {
-	case NoNewCommits:
-		return nil
-	case nil:
-		break
-	default:
-		panic(err)
-	}
-	if pack != nil {
-		defer pack.Close()
-	}
-	_, err = IndexAndCopyPack(c, IndexPackOptions{Verbose: true}, pack)
+func Fetch(c *Client, opts FetchOptions, rmt Remote) error {
+	opts.FetchPackOptions.All = true
+	opts.FetchPackOptions.Verbose = true
+	newrefs, err := FetchPack(c, opts.FetchPackOptions, rmt, nil)
 	if err != nil {
 		return err
 	}
-	for _, ref := range refs {
+	for _, ref := range newrefs {
 		if c.GitDir != "" {
-			refname := ref.Refname.String()
-			if strings.HasPrefix(refname, "refs/heads") {
-				os.MkdirAll(c.GitDir.File(File("refs/remotes/"+repository)).String(), 0755)
-				refname = strings.Replace(refname, "refs/heads/", "refs/remotes/"+repository+"/", 1)
+			if strings.HasPrefix(ref.Name, "refs/heads") {
+				// FIXME: This should use update ref and also
+				// print a better message.
+				os.MkdirAll(c.GitDir.File(File("refs/remotes/"+rmt.String())).String(), 0755)
+				refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/"+rmt.String()+"/", 1)
 				refloc := fmt.Sprintf("%s/%s", c.GitDir, refname)
-				fmt.Printf("Creating %s with %s", refloc, ref.Sha1)
+				fmt.Printf("Creating %s with %s\n", refloc, ref.Value)
 				ioutil.WriteFile(
 					refloc,
-					[]byte(ref.Sha1),
+					[]byte(ref.Value[:]),
 					0644,
 				)
 			}

--- a/git/pull.go
+++ b/git/pull.go
@@ -7,7 +7,7 @@ type PullOptions struct {
 	MergeOptions
 }
 
-func Pull(c *Client, opts PullOptions, repository string, remotebranches []string) error {
+func Pull(c *Client, opts PullOptions, repository Remote, remotebranches []string) error {
 	err := Fetch(c, opts.FetchOptions, repository)
 	if err != nil {
 		return err

--- a/git/remote.go
+++ b/git/remote.go
@@ -50,6 +50,21 @@ func (r Remote) IsStateless(c *Client) (bool, error) {
 	return strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://"), nil
 }
 
+// Gets a list of local references cached for this Remote
+func (r Remote) GetLocalRefs(c *Client) ([]Ref, error) {
+	allrefs, err := ShowRef(c, ShowRefOptions{}, nil)
+	if err != nil {
+		return nil, err
+	}
+	ourrefs := make([]Ref, 0, len(allrefs))
+	for _, rf := range allrefs {
+		if strings.HasPrefix(rf.Name, "refs/remotes/"+r.String()) {
+			ourrefs = append(ourrefs, rf)
+		}
+	}
+	return ourrefs, nil
+}
+
 // A RemoteConn represends a connection to a remote which communicates
 // with the remote.
 type RemoteConn interface {


### PR DESCRIPTION
This updates fetch to use fetch-pack (and adds support for declaring
"have" lines in fetch.)

The result should be that fetch now works over non-HTTP protocols as well.