### PR TITLE
Refresh stat info when doing high level diff or status command

### DIFF
--- a/git/diff.go
+++ b/git/diff.go
@@ -37,6 +37,9 @@ func Diff(c *Client, opt DiffOptions, paths []File) ([]HashDiff, error) {
 		}
 		return nil, nil
 	}
+	if err := refreshIndex(c); err != nil {
+		return nil, err
+	}
 	if opt.Staged {
 		head, err := c.GetHeadCommit()
 		if err != nil {

--- a/git/diffindex.go
+++ b/git/diffindex.go
@@ -14,7 +14,17 @@ type DiffIndexOptions struct {
 	Cached bool
 }
 
+// DiffIndex compares the index against a tree. If the index passed is nil, it reads
+// the index from the .git directory
 func DiffIndex(c *Client, opt DiffIndexOptions, index *Index, tree Treeish, paths []File) ([]HashDiff, error) {
+	if index == nil {
+		indx, err := c.GitDir.ReadIndex()
+		if err != nil {
+			return nil, err
+		}
+		index = indx
+	}
+
 	lsTreeOpts := LsTreeOptions{Recurse: true}
 	if len(paths) == 0 {
 		lsTreeOpts.FullTree = true

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -200,6 +200,14 @@ func UpdateIndexFromReader(c *Client, opts UpdateIndexOptions, r io.Reader) (*In
 
 func UpdateIndexRefresh(c *Client, idx *Index, opts UpdateIndexOptions) (*Index, error) {
 	for _, entry := range idx.Objects {
+		f, err := entry.PathName.FilePath(c)
+		if err != nil {
+			return nil, err
+		}
+		if !f.Exists() {
+			// Nothing to refresh
+			continue
+		}
 		if err := entry.RefreshStat(c); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This refreshes the index stat info before doing a "diff" or
"status" command, which appears to be more in line with what
the official git client does.

This avoids diffs where the diff says a file was changed but
has an empty diff, and status claiming that unmodified files are
modified.

(Extracted from #156 to see if it's this part or the other part of the change causing regressions. )