### PR TITLE
Use a ReaderAt instead of an in-memory cache to resolve deltas

### DIFF
--- a/git/packfile.go
+++ b/git/packfile.go
@@ -106,9 +106,12 @@ func (p PackfileHeader) ReadHeaderSize(r io.Reader) (PackEntryType, PackEntrySiz
 	}
 	switch entrytype {
 	case OBJ_REF_DELTA:
-		n, err := r.Read(refDelta)
-		if n != 20 || err != nil {
+		n, err := io.ReadFull(r, refDelta)
+		if err != nil {
 			panic(err)
+		}
+		if n != 20 {
+			panic(fmt.Sprintf("Could not read refDelta base. Got %v (%x) instead of 20 bytes", n, refDelta[:n]))
 		}
 		dataread = append(dataread, refDelta...)
 		sha, err := Sha1FromSlice(refDelta)


### PR DESCRIPTION
This retrieves objects from a pack file by using an io.ReaderAt
of the packfile rather an in-memory cache of objects that have
been found so far. The result is that the amount of memory required
to do a fetch or clone is proportional to the number of objects,
rather than proportional to the total fully resolved object size of
everything in the pack.

With this change, I was able to dgit clone https://github.com/golang/go
using 311Mb of RAM (according to top) in 12 minutes. (The clone then
paniced while trying to reset the index, but I was able to manually do
a "dgit reset --hard" and get a fully checked out copy of the Go repo.)

Partially resolves #147.