### PR TITLE
Add config cache to client to improve checkout time

### DIFF
--- a/git/config.go
+++ b/git/config.go
@@ -180,7 +180,7 @@ func (s *GitConfigSection) ParseValues(valueslines string) {
 		}
 		varname := strings.TrimSpace(split[0])
 
-		log.Printf("%v\n", varname)
+		log.Printf("Parsed config variable %v\n", varname)
 		s.values[varname] = strings.TrimSpace(strings.Join(split[1:], "="))
 
 	}

--- a/git/protectfs.go
+++ b/git/protectfs.go
@@ -4,34 +4,9 @@
 package git
 
 func protectHFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return false
-
+	return c.GetConfig("core.protectHFS") == "true"
 }
 
 func protectNTFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return false
+	return c.GetConfig("core.protectNTFS") == "true"
 }

--- a/git/protectfs_darwin.go
+++ b/git/protectfs_darwin.go
@@ -2,34 +2,9 @@ package git
 
 // protectHFS defaults to true on Mac
 func protectHFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return true
-
+	return config.GetConfig("core.protectHFS") != "false"
 }
 
 func protectNTFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return false
+	return config.GetConfig("core.protectNTFS") == "true"
 }

--- a/git/protectfs_darwin.go
+++ b/git/protectfs_darwin.go
@@ -2,9 +2,9 @@ package git
 
 // protectHFS defaults to true on Mac
 func protectHFS(c *Client) bool {
-	return config.GetConfig("core.protectHFS") != "false"
+	return c.GetConfig("core.protectHFS") != "false"
 }
 
 func protectNTFS(c *Client) bool {
-	return config.GetConfig("core.protectNTFS") == "true"
+	return c.GetConfig("core.protectNTFS") == "true"
 }

--- a/git/protectfs_windows.go
+++ b/git/protectfs_windows.go
@@ -1,35 +1,10 @@
 package git
 
 func protectHFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectHFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return false
-
+	return c.GetConfig("core.protectHFS") == "true"
 }
 
 // protectNTFS defaults to true on windows
 func protectNTFS(c *Client) bool {
-	config, err := LoadLocalConfig(c)
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	config, err = LoadGlobalConfig()
-	if err == nil {
-		if cfg, _ := config.GetConfig("core.protectNTFS"); cfg != "" {
-			return cfg == "true"
-		}
-	}
-	return true
+	return c.GetConfig("core.protectNTFS") != "false"
 }


### PR DESCRIPTION
Since the protectHFS and protectNTFS config options were added to dgit
in order to pass more of the official git tests, readtree has been
looking them up for each file.  This results in the global and local
configs each getting parsed twice per file in the repo when doing a
checkout.  (This is obviously particularly bad for large repos.)

This adds 2 levels of caching to looking up a config option:

1. The parsed config files (both local and global) are stored in the
   Client so that they only need to be parsed once per command invocation.
2. A map is used to store values that have already been looked up
   since they shouldn't change between git invocations (with the exception
   of the "git config" command.)

read-tree is currently the only thing updated to use the new
client.GetConfig function, but it would probably be a good idea to use
it consistently throughout dgit.