### PR TITLE
Fix panic when retrieving a size 0 object from a pack file.

### DIFF
--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -136,9 +136,15 @@ func (idx PackfileIndexV2) getObjectAtOffset(r io.ReaderAt, offset int64, metaOn
 	// but we're very generous here since this doesn't allocate anything but
 	// just determines how much data the SectionReader will read before
 	// returning an EOF.
-	datareader := io.NewSectionReader(r, offset+int64(len(rawheader)), int64(sz*3))
-	if !metaOnly || t == OBJ_OFS_DELTA || t == OBJ_REF_DELTA {
-		rawdata = p.readEntryDataStream1(datareader)
+	if sz != 0 {
+		datareader := io.NewSectionReader(r, offset+int64(len(rawheader)), int64(sz*3))
+		if !metaOnly || t == OBJ_OFS_DELTA || t == OBJ_REF_DELTA {
+			rawdata = p.readEntryDataStream1(datareader)
+		}
+	} else {
+		// If it's size 0, sz*3 would immediately return io.EOF and cause
+		// panic, so we just directly make the rawdata slice.
+		rawdata = make([]byte, 0)
 	}
 
 	// The way we calculate the hash changes based on if it's a delta


### PR DESCRIPTION
When attempting to look up an object of size 0 (ie. an empty file)
in a git packfile, the SectionReader allocated would return EOF after
0*3 = 0 bytes are read, causing a panic when trying to read the header
for the zlib stream.

This avoids the overhead of reading the stream entirely by just directly
allocating a 0 byte slice. This should fix the panic when trying to clone
https://github.com/golang/go.