### PR TITLE
Add support for rev-parse foo^0

### DIFF
--- a/git/revparse.go
+++ b/git/revparse.go
@@ -207,7 +207,16 @@ func RevParseCommitish(c *Client, opt *RevParseOptions, arg string) (cmt Commiti
 				return
 			}
 			// FIXME: This should actually implement various ^ and @{} modifiers
-			if mod == "^" {
+			switch mod {
+			case "^0":
+				basecmt, newerr := cmt.CommitID(c)
+				if newerr != nil {
+					err = newerr
+					return
+				}
+				cmt = basecmt
+				return
+			case "^":
 				basecmt, newerr := cmt.CommitID(c)
 				if newerr != nil {
 					err = newerr


### PR DESCRIPTION
This adds support for git rev-parse foo^0 to get the commit
that foo references. It's effectively a no-op for RevParseCommitish,
but a number of tests from the official test suite depend on it,
so explicitly parsing it makes them more likely to pass.