### PR TITLE
Add annotated tag support

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"strings"
 
 	"github.com/driusan/dgit/git"
 )
@@ -31,8 +33,37 @@ func Tag(c *git.Client, args []string) error {
 	flags.BoolVar(&options.IgnoreCase, "ignore-case", false, "Sorting and filtering are case insensitive")
 	flags.BoolVar(&options.IgnoreCase, "i", false, "Alias of --ignore-case")
 
+	flags.BoolVar(&options.Annotated, "annotated", false, "Create an annotated tag")
+	flags.BoolVar(&options.Annotated, "a", false, "Alias of --annotated")
+
+	var message []string
+	flags.Var(newMultiStringValue(&message), "message", "Use the given message for the annotated tag")
+	flags.Var(newMultiStringValue(&message), "m", "Alias of --message")
+
+	var messageFile string
+	flags.Var(newAliasedStringValue(&messageFile, ""), "file", "Use the contents of file for the annotated tag message")
+	flags.Var(newAliasedStringValue(&messageFile, ""), "F", "Alias of --file")
+
 	flags.Parse(args)
+	if messageFile != "" {
+		f, err := ioutil.ReadFile(messageFile)
+		if err != nil {
+			return err
+		}
+		message = append(message, string(f))
+	}
+	if len(message) > 0 || messageFile != "" {
+		options.Annotated = true
+	}
 	tagnames := flags.Args()
+	var finalMessage string
+	if options.Annotated {
+		finalMessage = strings.Join(message, "\n\n") + "\n"
+		// FIXME: spawn an editor if no message is provided
+		if finalMessage == "\n" || finalMessage == "" {
+			return fmt.Errorf("No message provided for annotated tag")
+		}
+	}
 	if options.List {
 		tags, err := git.TagList(c, options, tagnames)
 		if err != nil {
@@ -50,13 +81,13 @@ func Tag(c *git.Client, args []string) error {
 		printTags(tags)
 		return nil
 	case 1:
-		return git.TagCommit(c, options, tagnames[0], nil)
+		return git.TagCommit(c, options, tagnames[0], nil, finalMessage)
 	case 2:
 		commit, err := git.RevParseCommitish(c, &git.RevParseOptions{}, tagnames[1])
 		if err != nil {
 			return err
 		}
-		return git.TagCommit(c, options, tagnames[0], commit)
+		return git.TagCommit(c, options, tagnames[0], commit, finalMessage)
 	default:
 		return fmt.Errorf("Invalid tag usage")
 	}

--- a/git/mktag.go
+++ b/git/mktag.go
@@ -133,7 +133,7 @@ func Mktag(c *Client, r io.Reader) (Sha1, error) {
 		pos := len(lines[0]) + len(lines[1]) + len(lines[2]) + 3 + len("tagger ") + len(taggerPieces[1]) + len(taggerPieces[2]) + 3 + len(timepieces[1]) + len(timepieces[2])
 		return Sha1{}, fmt.Errorf(`error: char%d: malformed tag timezone`, pos)
 	}
-	if lines[4] != "\n" {
+	if lines[4] != "" && lines[4][0] != '\n' {
 		// There should have been a blank line
 		pos := len(lines[0]) + len(lines[1]) + len(lines[2]) + len(lines[3]) + 4
 		return Sha1{}, fmt.Errorf("error: char%d: trailing garbage in tag header", pos)


### PR DESCRIPTION
This adds support for "git tag -a"

Fixes #20.