### PR TITLE
Clean up c.GetConfig changes

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -296,19 +296,23 @@ func (c *Client) GetAuthor(t *time.Time) Person {
 	}
 
 	// system defaults
-	if name == "" {
+	if name == "" || email == "" {
 		u, err := user.Current()
 		if err != nil {
 			panic(err)
 		}
-		name = u.Name
-	}
-	if email == "" {
-		h, err := os.Hostname()
-		if err != nil {
-			panic(err)
+
+		if name == "" {
+			name = u.Name
 		}
-		email = fmt.Sprintf("%s@%s", name, h)
+
+		if email == "" {
+			h, err := os.Hostname()
+			if err != nil {
+				panic(err)
+			}
+			email = fmt.Sprintf("%s@%s", u.Name, h)
+		}
 	}
 	person.Name = name
 	person.Email = email
@@ -337,20 +341,23 @@ func (c *Client) GetCommitter(t *time.Time) (Person, error) {
 	}
 
 	// system defaults
-	if name == "" {
+	if name == "" || email == "" {
 		u, err := user.Current()
 		if err != nil {
 			panic(err)
 		}
-		name = u.Name
-		configerr = NoGlobalConfig
-	}
-	if email == "" {
-		h, err := os.Hostname()
-		if err != nil {
-			panic(err)
+
+		if name == "" {
+			name = u.Name
 		}
-		email = fmt.Sprintf("%s@%s", name, h)
+
+		if email == "" {
+			h, err := os.Hostname()
+			if err != nil {
+				panic(err)
+			}
+			email = fmt.Sprintf("%s@%s", u.Name, h)
+		}
 		configerr = NoGlobalConfig
 	}
 	person.Name = name

--- a/git/client.go
+++ b/git/client.go
@@ -308,7 +308,7 @@ func (c *Client) GetAuthor(t *time.Time) Person {
 		if err != nil {
 			panic(err)
 		}
-		email = fmt.Sprintf("%s@%s", u.Username, h)
+		email = fmt.Sprintf("%s@%s", name, h)
 	}
 	person.Name = name
 	person.Email = email
@@ -350,7 +350,7 @@ func (c *Client) GetCommitter(t *time.Time) (Person, error) {
 		if err != nil {
 			panic(err)
 		}
-		email = fmt.Sprintf("%s@%s", u.Username, h)
+		email = fmt.Sprintf("%s@%s", name, h)
 		configerr = NoGlobalConfig
 	}
 	person.Name = name

--- a/git/client.go
+++ b/git/client.go
@@ -287,31 +287,31 @@ func (c *Client) GetAuthor(t *time.Time) Person {
 	name := os.Getenv("GIT_AUTHOR_NAME")
 	email := os.Getenv("GIT_AUTHOR_EMAIL")
 
-	if name != "" {
-		person.Name = name
-	} else {
-		person.Name = c.GetConfig("user.name")
+	// git config
+	if name == "" {
+		name = c.GetConfig("user.name")
+	}
+	if email == "" {
+		email = c.GetConfig("user.email")
 	}
 
-	if email != "" {
-		person.Email = email
-	} else {
-		person.Email = c.GetConfig("user.email")
-	}
-
-	// .gitconfig doesn't exist, so use the system defaults.
-	if person.Name == "" || person.Email == "" {
+	// system defaults
+	if name == "" {
 		u, err := user.Current()
 		if err != nil {
 			panic(err)
 		}
-		person.Name = u.Name
+		name = u.Name
+	}
+	if email == "" {
 		h, err := os.Hostname()
 		if err != nil {
 			panic(err)
 		}
-		person.Email = fmt.Sprintf("%s@%s", u.Username, h)
+		email = fmt.Sprintf("%s@%s", u.Username, h)
 	}
+	person.Name = name
+	person.Email = email
 	person.Time = t
 	return person
 }
@@ -328,32 +328,33 @@ func (c *Client) GetCommitter(t *time.Time) (Person, error) {
 	email := os.Getenv("GIT_COMMITTER_EMAIL")
 	var configerr error
 
-	if name != "" {
-		person.Name = name
-	} else {
-		person.Name = c.GetConfig("user.name")
+	// git config
+	if name == "" {
+		name = c.GetConfig("user.name")
+	}
+	if email == "" {
+		email = c.GetConfig("user.email")
 	}
 
-	if email != "" {
-		person.Email = email
-	} else {
-		person.Email = c.GetConfig("user.email")
-	}
-
-	// .gitconfig doesn't exist, so use the system defaults.
-	if person.Name == "" || person.Email == "" {
+	// system defaults
+	if name == "" {
 		u, err := user.Current()
 		if err != nil {
 			panic(err)
 		}
-		person.Name = u.Name
+		name = u.Name
+		configerr = NoGlobalConfig
+	}
+	if email == "" {
 		h, err := os.Hostname()
 		if err != nil {
 			panic(err)
 		}
-		person.Email = fmt.Sprintf("%s@%s", u.Username, h)
+		email = fmt.Sprintf("%s@%s", u.Username, h)
 		configerr = NoGlobalConfig
 	}
+	person.Name = name
+	person.Email = email
 	person.Time = t
 	return person, configerr
 }


### PR DESCRIPTION
PR #170 changed some functions in client.go to use `c.GetConfig`. The problem is that `GetConfig` returns empty string if config does not exist.

This PR does not check the config presence on the system, but at least does two separate checks for empty user/email options.  It'll still return `NoGlobalConfig` if options are empty even if the config exists.