### PR TITLE
Fix V2 Protocol clones from GitHub

### DIFF
--- a/git/clone.go
+++ b/git/clone.go
@@ -83,7 +83,6 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 		return err
 	}
 
-	// FetchPack returned refs for V1, 
 	for _, ref := range refs {
 		if !strings.HasPrefix(ref.Name, "refs/heads/") {
 			// FIXME: This should have been done by GetRefs()

--- a/git/clone.go
+++ b/git/clone.go
@@ -62,6 +62,9 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 		return err
 	}
 	config, err := LoadLocalConfig(c)
+	if err != nil {
+		return err
+	}
 	config.SetConfig("remote.origin.url", rmt.String())
 	br := opts.Branch
 	if br == "" {
@@ -79,6 +82,8 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 	if err := config.WriteConfig(); err != nil {
 		return err
 	}
+
+	// FetchPack returned refs for V1, 
 	for _, ref := range refs {
 		if !strings.HasPrefix(ref.Name, "refs/heads/") {
 			// FIXME: This should have been done by GetRefs()

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -126,7 +126,7 @@ func parseRemoteInitialConnection(r io.Reader, stateless bool) (uint8, map[strin
 			line = loadLine(r)
 		}
 	}
-	
+
 	switch line {
 	case "version 2", "version 2\n":
 		cap := make(map[string]map[string]struct{})

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -116,7 +116,19 @@ func (s *smartHTTPConn) OpenConn() error {
 }
 
 func parseRemoteInitialConnection(r io.Reader, stateless bool) (uint8, map[string]map[string]struct{}, []Ref, error) {
-	switch line := loadLine(r); line {
+	line := loadLine(r)
+	switch line {
+	case "# service=git-upload-pack", "# service=git-upload-pack\n":
+		println("Upload pack")
+		// An http connection starts with the service announcement. We
+		// need to parse the next line
+		line = loadLine(r)
+		if line == "" {
+			line = loadLine(r)
+		}
+	}
+	
+	switch line {
 	case "version 2", "version 2\n":
 		cap := make(map[string]map[string]struct{})
 		for line := loadLine(r); line != ""; line = loadLine(r) {
@@ -137,14 +149,6 @@ func parseRemoteInitialConnection(r io.Reader, stateless bool) (uint8, map[strin
 		}
 		return 2, cap, nil, nil
 
-	case "# service=git-upload-pack", "# service=git-upload-pack\n":
-		// An http connection starts with the service announcement. We
-		// need to parse the next line
-		line = loadLine(r)
-		if line == "" {
-			line = loadLine(r)
-		}
-		fallthrough
 	default:
 		cap := make(map[string]map[string]struct{})
 		var refs []Ref
@@ -253,7 +257,7 @@ func (s smartHTTPConn) GetRefs(opts LsRemoteOptions, patterns []string) ([]Ref, 
 		}
 		defer resp.Body.Close()
 		for line := loadLine(resp.Body); line != ""; line = loadLine(resp.Body) {
-			ref, err := parseLsRef(string(line))
+			ref, err := parseLsRef(line)
 			if err != nil {
 				return nil, err
 			}
@@ -456,5 +460,6 @@ func parseLsRef(s string) (Ref, error) {
 		return Ref{}, err
 	}
 	name := string(s[41:])
+	name = strings.TrimSuffix(name, "\n")
 	return Ref{Name: name, Value: sha1}, nil
 }

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -119,7 +119,6 @@ func parseRemoteInitialConnection(r io.Reader, stateless bool) (uint8, map[strin
 	line := loadLine(r)
 	switch line {
 	case "# service=git-upload-pack", "# service=git-upload-pack\n":
-		println("Upload pack")
 		// An http connection starts with the service announcement. We
 		// need to parse the next line
 		line = loadLine(r)

--- a/git/pull.go
+++ b/git/pull.go
@@ -9,7 +9,10 @@ type PullOptions struct {
 
 func Pull(c *Client, opts PullOptions, repository Remote, remotebranches []string) error {
 	err := Fetch(c, opts.FetchOptions, repository)
-	if err != nil {
+	if err != nil && err.Error() != "Already up to date." {
+		// If fetch says we have all the refs, that doesn't
+		// mean that they're merged into the current branch
+		// so we don't error out.
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -213,6 +213,9 @@ func main() {
 		subcommandUsage = "[<repository [<refspec>...]]"
 		if err := cmd.Pull(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
+			if err.Error() == "Already up to date." {
+				os.Exit(0)
+			}
 			os.Exit(2)
 		}
 	case "reset":


### PR DESCRIPTION
GitHub appears to have upgraded to the git V2 protocol
(which dgit tries to support), but switching the protocol
over exposed some bugs in dgit.

In particular, the service advertisement over http combined
with the version 2 advertisement wasn't being parsed properly,
and newlines at the end of refs weren't being stripped properly.

This fixes both those bugs and clones should now work again.

Fixes #178