### PR TITLE
Partial implementation of git-archive

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/driusan/dgit/git"
+)
+
+func argsParseCompressionLevel(opts *git.ArchiveOptions, args []string) []string {
+	for i, arg := range args {
+		if len(arg) < 2 || arg[0] != '-' {
+			continue
+		}
+		startIndex := 1
+		if arg[1] == '-' {
+			startIndex++
+			if len(arg) == 2 {
+				continue
+			}
+		}
+
+		// slice the dash
+		value := arg[startIndex:]
+
+		// Try to convert to integer
+		if v, err := strconv.Atoi(value); err != nil {
+			// The value is NaN
+			continue
+		} else {
+			// The compression value must be between 0..9
+			if v >= 0 && v <= 9 {
+				opts.CompressionLevel = v
+			}
+			// remove this value from the arg list
+			return append(args[:i], args[i+1:]...)
+		}
+	}
+	return args
+}
+
+func Archive(c *git.Client, args []string) error {
+	flags := flag.NewFlagSet("archive", flag.ExitOnError)
+	flags.SetOutput(flag.CommandLine.Output())
+	flags.Usage = func() {
+		flag.Usage()
+		fmt.Fprintf(flag.CommandLine.Output(), "\n\nOptions:\n")
+		flags.PrintDefaults()
+	}
+
+	opts := git.ArchiveOptions{}
+
+	//flags.BoolVar(&opts.Verbose, "verbose", false, "Report archived files on stderr")
+	//flags.BoolVar(&opts.Verbose, "v", false, "Alias for --verbose")
+	flags.Var(newNotimplBoolValue(), "verbose", "Not implemented")
+	flags.Var(newNotimplBoolValue(), "v", "Not implemented")
+
+	flags.StringVar(&opts.BasePrefix, "prefix", "", "Prepend prefix to each pathname in the archive")
+	flags.StringVar(&opts.OutputFile, "output", "", "Write the archive to this file")
+	flags.StringVar(&opts.OutputFile, "o", "", "Alias for --output")
+
+	//flags.BoolVar(&opts.WorktreeAttributes, "worktree-attributes", false, "Not implemented")
+	flags.Var(newNotimplBoolValue(), "worktree-attributes", "Not implemented")
+
+	flags.BoolVar(&opts.List, "list", false, "List supported archive formats")
+	flags.BoolVar(&opts.List, "l", false, "Alias for --list")
+
+	flags.Var(newNotimplStringValue(), "remote", "Not implemented")
+	flags.Var(newNotimplStringValue(), "exec", "Not implemented")
+
+	flags.StringVar(&opts.ArchiveFormat, "format", "", "Archive format")
+
+	flags.IntVar(&opts.CompressionLevel, "0", 0, "Store only")
+	flags.IntVar(&opts.CompressionLevel, "9", 9, "Highest compression level")
+
+	// if the args is empty, print usage.
+	if len(args) == 0 {
+		flags.Usage()
+		os.Exit(2)
+	}
+
+	flags.Parse(args)
+
+	var treeish string
+
+	// Since the Flag parsing stops before the first non-flag argument
+	// there can be remaining arguments to parse.
+	// For example calling dgit with the followings args
+	// "dgit archive HEAD -o test.tar" the -o flag will not be parsed
+	// so we must parse the flags again if there are remaining args to parse.
+	if flags.NArg() > 1 {
+		args := flags.Args()
+
+		// The first not parsed arg should be the treeish
+		treeish = args[0]
+
+		// Check if there's a -1..8 compression level flag
+		args = argsParseCompressionLevel(&opts, args[1:])
+
+		// Parse the flags again skipping the first arg
+		flags.Parse(args)
+
+		// After this second parse there should not be any arg left to parse.
+		if flags.NArg() > 0 {
+			flags.Usage()
+			os.Exit(2)
+		}
+	} else if flags.NArg() == 1 {
+		args := flags.Args()
+		treeish = args[0]
+	}
+
+	if opts.List {
+		formatList := git.ArchiveFormatList()
+		for _, f := range formatList {
+			fmt.Println(f)
+		}
+		return nil
+	}
+
+	// Special case for "HEAD:folder/"
+	if h := strings.SplitN(treeish, ":", 2); len(h) == 2 {
+		return fmt.Errorf("<path> option not implemented.")
+		// TODO: path option not implemented.
+		//treeish = h[0]
+		//opts.IncludePath = h[1]
+	}
+
+	return git.Archive(c, opts, treeish)
+}

--- a/git/archive.go
+++ b/git/archive.go
@@ -114,10 +114,6 @@ func createTarArchive(c *Client, opts ArchiveOptions, tgz bool, sha Sha1, entrie
 			hdr.Name = opts.BasePrefix + e.PathName.String()
 			hdr.Size = int64(obj.GetSize())
 			hdr.ModTime = mtime
-			hdr.Uid = 0
-			hdr.Gid = 0
-			hdr.Uname = "root"
-			hdr.Gname = "root"
 
 			// TODO: Mask the mode. by default the mask is 0002 (turn off write bit)
 			// but can be changed using tar.umask config.

--- a/git/archive.go
+++ b/git/archive.go
@@ -1,0 +1,210 @@
+package git
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type ArchiveOptions struct {
+	Verbose            bool
+	List               bool
+	WorktreeAttributes bool
+	ArchiveFormat      string
+	BasePrefix         string
+	OutputFile         string
+	CompressionLevel   int
+}
+
+type ArchiveFormat int
+
+const (
+	archiveUnknow = ArchiveFormat(iota)
+	archiveTar
+	archiveTarGzip
+
+//	archiveZip
+)
+
+var supportedArchiveFormats = map[string]ArchiveFormat{
+	"tar":    archiveTar,
+	"tgz":    archiveTarGzip,
+	"tar.gz": archiveTarGzip,
+	//	"zip":    archiveZip,
+}
+
+func findOutputFileFormat(output string) ArchiveFormat {
+	// if the output is empty return the default value, a tarball.
+	if output == "" {
+		return archiveTar
+	}
+
+	for k, v := range supportedArchiveFormats {
+		if strings.HasSuffix(strings.ToLower(output), k) {
+			return v
+		}
+	}
+	// The archive format is not found, return unknow.
+	return archiveUnknow
+}
+
+func createTarArchive(c *Client, opts ArchiveOptions, tgz bool, sha Sha1, entries []*IndexEntry) error {
+	fileOutput := os.Stdout
+
+	// If the output file is not empty use it instead of stdout
+	if opts.OutputFile != "" {
+		if file, err := os.Create(opts.OutputFile); err == nil {
+			fileOutput = file
+			defer file.Close()
+		} else {
+			return err
+		}
+	}
+
+	mtime := time.Now()
+
+	// If the sha is a tree we set the file modification time to the current time
+	// otherwise we must use the commit time.
+	if sha.Type(c) != "tree" {
+		if t, err := CommitID(sha).GetDate(c); err == nil {
+			mtime = t
+		}
+	}
+
+	var tw *tar.Writer
+
+	//
+	if tgz {
+		gw := gzip.NewWriter(fileOutput)
+		defer gw.Close()
+
+		tw = tar.NewWriter(gw)
+		defer tw.Close()
+	} else {
+		tw = tar.NewWriter(fileOutput)
+		defer tw.Close()
+	}
+
+	// Write the pax header
+	hdr := &tar.Header{
+		Typeflag: tar.TypeXGlobalHeader,
+		Name:     "pax_global_header",
+		PAXRecords: map[string]string{
+			"comment": sha.String(),
+		},
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		o, err := c.GetObject(e.Sha1)
+		if err != nil {
+			return err
+		}
+		if obj, ok := o.(GitBlobObject); ok {
+			hdr := &tar.Header{}
+			hdr.Name = opts.BasePrefix + e.PathName.String()
+			hdr.Size = int64(obj.GetSize())
+			hdr.ModTime = mtime
+			hdr.Uid = 0
+			hdr.Gid = 0
+			hdr.Uname = "root"
+			hdr.Gname = "root"
+
+			// TODO: Mask the mode. by default the mask is 0002 (turn off write bit)
+			// but can be changed using tar.umask config.
+			switch e.Mode {
+			case ModeBlob:
+				hdr.Mode = 0644
+			case ModeExec:
+				hdr.Mode = 0755
+			default:
+				hdr.Mode = 0644
+			}
+
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if _, err := tw.Write(o.GetContent()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Return the list of supported archive file format
+func ArchiveFormatList() []string {
+	formats := make([]string, 0, len(supportedArchiveFormats))
+	for key := range supportedArchiveFormats {
+		formats = append(formats, key)
+	}
+	return formats
+}
+
+func Archive(c *Client, opts ArchiveOptions, arg string) error {
+	format := archiveUnknow
+
+	//
+	treeish, err := RevParseTreeish(c, &RevParseOptions{}, arg)
+	if err != nil {
+		return err
+	}
+
+	//
+	if opts.ArchiveFormat == "" {
+		// if the output file is set try to find
+		// the archive format from the file extension.
+		if opts.OutputFile != "" {
+			format = findOutputFileFormat(opts.OutputFile)
+			if format == archiveUnknow {
+				format = archiveTar
+			}
+		} else {
+			// Default is tarball
+			format = archiveTar
+		}
+	} else {
+		format = findOutputFileFormat(opts.ArchiveFormat)
+		if format == archiveUnknow {
+			return fmt.Errorf("Unknow archive format '%s'", opts.ArchiveFormat)
+		}
+	}
+
+	// commit hash
+	var sha1 Sha1
+
+	// if the input it's a tag we must resolve it to a commit
+	if h, ok := treeish.(Ref); ok {
+		refspec := RefSpec(h.Name)
+		if c, err := refspec.CommitID(c); err != nil {
+			return err
+		} else {
+			treeish = c
+		}
+	}
+
+	if s, ok := treeish.(CommitID); ok {
+		sha1 = Sha1(s)
+	} else {
+		return fmt.Errorf("Can't convert treeish to commit id")
+	}
+
+	lstree, err := LsTree(c, LsTreeOptions{Recurse: true}, treeish, nil)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case archiveTar:
+		return createTarArchive(c, opts, false, sha1, lstree)
+	case archiveTarGzip:
+		return createTarArchive(c, opts, true, sha1, lstree)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/driusan/dgit/cmd"
-	"github.com/driusan/dgit/git"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/driusan/dgit/cmd"
+	"github.com/driusan/dgit/git"
 )
 
 var InvalidArgument error = errors.New("Invalid argument to function")
@@ -423,6 +424,13 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case "archive":
+		globalOptsInUsage = false
+		subcommandUsage = "<tree-ish> [<path>...]"
+		if err := cmd.Archive(c, args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	case "help":
 		flag.CommandLine.SetOutput(os.Stdout)
 		flag.Usage()
@@ -474,6 +482,7 @@ func main() {
    var              Show a Git logical variable
    submodule        Initialize, update or inspect submodules
    showref          List references in a local repository
+   archive
 `)
 
 		os.Exit(0)

--- a/status.txt
+++ b/status.txt
@@ -13,7 +13,9 @@ Command	Status	Reference git version  Notes
 add            HappyPath     git 2.9.2              (5) Missing --edit, --interactive, --intent-to-add, --ignore-errors, --ignore-missing, and --no-warn-embedded-repo
                                                     (3) Passed to update-index or ls-files, but missing plumbing support: --force, --refresh, --chmod
 am             None
-archive        None
+archive        HappyPath     git 2.9.2              (4) Missing --verbose, --worktree-attributes, --remote, --exec options.
+                                                        Missing options from configuration (tar.umask, tar.<format>.command, tar.<format>.remote).
+                                                        Missing symlinks support.
 branch         HappyPath     git 2.9.2
 bisect         None
 bundle         None


### PR DESCRIPTION
While i do understand that Plumbing commands are a priority I partially implemented the git-archive command to better understand the codebase.

### **What's missing?**
--verbose
--worktree-attributes
--remote
--exec
\<path> optional arg

**Usage of config options**
tar.umask
tar.\<format>.command
tar.\<format>.remote
symlinks support
git submodule?

**All of the examples in the git docs works except of this:**
`git archive TAG fails if the ref file [refs/tags/TAG] doesn't exist.`

If you clone a repo the ref file doesn't exist, looks like there is something not implemented yet because dgit tag also shows nothing.

`git archive --format=zip --prefix=git-docs/ HEAD:Documentation/ > git-1.4.0-docs.zip`

`git archive --format=tar --prefix=git-1.4.0/ v1.4.0^{tree} | gzip >git-1.4.0.tar.gz `
(_are the ^{tree} modifier not implemented?_)

`git config tar.tar.xz.command "xz -c" `



