### PR TITLE
Add skeleton of git remote show command

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -2,8 +2,22 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/driusan/dgit/git"
 )
+
+func printRemotes(c *git.Client, opts git.RemoteOptions) error {
+	remotes, err := git.RemoteList(c, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range remotes {
+		fmt.Println(r.Name())
+	}
+	return nil
+}
 
 func Remote(c *git.Client, args []string) error {
 	flags := newFlagSet("remote")
@@ -12,7 +26,7 @@ func Remote(c *git.Client, args []string) error {
 	flags.Parse(args)
 	args = flags.Args()
 	if len(args) < 1 {
-		return fmt.Errorf("Missing remote subcommand")
+		return printRemotes(c, opts)
 	}
 	switch args[0] {
 	case "add":
@@ -21,6 +35,16 @@ func Remote(c *git.Client, args []string) error {
 		}
 		aopts := git.RemoteAddOptions{opts}
 		return git.RemoteAdd(c, aopts, args[1], args[2])
+	case "show":
+		sflags := newFlagSet("remote-show")
+		sopts := git.RemoteShowOptions{RemoteOptions: opts}
+		sflags.BoolVar(&sopts.NoQuery, "n", false, "Do not query remotes with ls-remote")
+		sflags.Parse(args[1:])
+		args = sflags.Args()
+		if len(args) < 1 {
+			return printRemotes(c, opts)
+		}
+		return git.RemoteShow(c, sopts, git.Remote(args[0]), os.Stdout)
 	default:
 		return fmt.Errorf("Remote subcommand %v not implemented", args[0])
 	}

--- a/git/config.go
+++ b/git/config.go
@@ -151,6 +151,22 @@ func (g *GitConfig) GetConfigList() []string {
 	return list
 }
 
+// Gets all config sections that match name and subsection. The empty
+// string matches all names/subsections.
+func (g *GitConfig) GetConfigSections(name, subsection string) []GitConfigSection {
+	matches := make([]GitConfigSection, 0, len(g.sections))
+	for _, sect := range g.sections {
+		if name != "" && sect.name != name {
+			continue
+		}
+		if subsection != "" && subsection != sect.subsection {
+			continue
+		}
+		matches = append(matches, sect)
+	}
+	return matches
+}
+
 func (g GitConfig) WriteFile(w io.Writer) {
 	for _, section := range g.sections {
 		if section.subsection == "" {

--- a/git/remote.go
+++ b/git/remote.go
@@ -50,6 +50,10 @@ func (r Remote) String() string {
 	return string(r)
 }
 
+func (r Remote) Name() string {
+	return string(r)
+}
+
 func (r Remote) IsStateless(c *Client) (bool, error) {
 	url, err := r.RemoteURL(c)
 	if err != nil {
@@ -195,8 +199,15 @@ func (r sharedRemoteConn) ProtocolVersion() uint8 {
 type RemoteOptions struct {
 	Verbose bool
 }
+
 type RemoteAddOptions struct {
 	RemoteOptions
+}
+type RemoteShowOptions struct {
+	RemoteOptions
+
+	// Do not query the remote with ls-remote, only show the local cache.
+	NoQuery bool
 }
 
 func RemoteAdd(c *Client, opts RemoteAddOptions, name, url string) error {
@@ -222,4 +233,25 @@ func RemoteAdd(c *Client, opts RemoteAddOptions, name, url string) error {
 		fmt.Sprintf("+refs/heads/*:refs/remotes/%v/*", name),
 	)
 	return config.WriteConfig()
+}
+
+// Retrieves a list of remotes set up in the local git repository
+// for Client c.
+func RemoteList(c *Client, opts RemoteOptions) ([]Remote, error) {
+	config, err := LoadLocalConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	configs := config.GetConfigSections("remote", "")
+	remotes := make([]Remote, 0, len(configs))
+	for _, cfg := range configs {
+		remotes = append(remotes, Remote(cfg.subsection))
+	}
+	return remotes, nil
+}
+
+// Prints the remote named r in the format of "git remote show r" to destination
+// w.
+func RemoteShow(c *Client, opts RemoteShowOptions, r Remote, w io.Writer) error {
+	return fmt.Errorf("Show not implemented")
 }


### PR DESCRIPTION
Implements the variant of git remote show where it lists the
remotes that are configured for a repository, but not the variant
where it shows the details of a single remote.