### PR TITLE
Add remote show and remote get-url subcommands

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -35,6 +35,25 @@ func Remote(c *git.Client, args []string) error {
 		}
 		aopts := git.RemoteAddOptions{opts}
 		return git.RemoteAdd(c, aopts, args[1], args[2])
+	case "get-url":
+		uflags := newFlagSet("remote-get-url")
+		urlopts := git.RemoteGetURLOptions{RemoteOptions: opts}
+		uflags.BoolVar(&urlopts.Push, "push", false, "Print push URLs, not fetch URLs")
+		uflags.BoolVar(&urlopts.All, "all", false, "Print all URLs, not just the first")
+		uflags.Parse(args[1:])
+		args = uflags.Args()
+		if len(args) < 1 {
+			uflags.Usage()
+			os.Exit(1)
+		}
+		urls, err := git.RemoteGetURL(c, urlopts, git.Remote(args[0]))
+		if err != nil {
+			return err
+		}
+		for _, u := range urls {
+			fmt.Println(u)
+		}
+		return nil
 	case "show":
 		sflags := newFlagSet("remote-show")
 		sopts := git.RemoteShowOptions{RemoteOptions: opts}

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -39,7 +39,7 @@ func Remote(c *git.Client, args []string) error {
 		uflags := newFlagSet("remote-get-url")
 		urlopts := git.RemoteGetURLOptions{RemoteOptions: opts}
 		uflags.BoolVar(&urlopts.Push, "push", false, "Print push URLs, not fetch URLs")
-		uflags.BoolVar(&urlopts.All, "all", false, "Print all URLs, not just the first")
+		uflags.BoolVar(&urlopts.All, "all", false, "Print all URLs, not just the first (not implemented)")
 		uflags.Parse(args[1:])
 		args = uflags.Args()
 		if len(args) < 1 {

--- a/git/foreachref.go
+++ b/git/foreachref.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Calls callback for each ref under c's GitDir which has prefix as a prefix.
+func ForEachRefCallback(c *Client, prefix string, callback func(*Client, Ref) error) error {
+	// FIXME: Include packed refs.
+	err := filepath.Walk(
+		c.GitDir.File("refs").String(),
+		func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() {
+				return nil
+			}
+			refname := strings.TrimPrefix(path, c.GitDir.String()+"/")
+			if strings.HasPrefix(refname, prefix) {
+				r, err := parseRef(c, refname)
+				if err != nil {
+					return err
+				}
+				if err := callback(c, r); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
+	return err
+}

--- a/git/remote.go
+++ b/git/remote.go
@@ -210,6 +210,12 @@ type RemoteShowOptions struct {
 	NoQuery bool
 }
 
+type RemoteGetURLOptions struct {
+	RemoteOptions
+	Push bool
+	All  bool
+}
+
 func RemoteAdd(c *Client, opts RemoteAddOptions, name, url string) error {
 	if name == "" {
 		return fmt.Errorf("Missing remote name")
@@ -253,5 +259,22 @@ func RemoteList(c *Client, opts RemoteOptions) ([]Remote, error) {
 // Prints the remote named r in the format of "git remote show r" to destination
 // w.
 func RemoteShow(c *Client, opts RemoteShowOptions, r Remote, w io.Writer) error {
+	if !opts.NoQuery {
+		return fmt.Errorf("Only show -n is implemented")
+	}
 	return fmt.Errorf("Show not implemented")
+}
+
+// Implements the "git remote get-url" command.
+//
+// BUG(driusan): Note that specifying the Push option to RemoteGetURL currently
+// always reports the same value as not specifying the Push option because the
+// rest of dgit doesn't implement things in a way that differentiates them either.
+// Also note that All is not implemented.
+func RemoteGetURL(c *Client, opts RemoteGetURLOptions, r Remote) ([]string, error) {
+	u, err := r.RemoteURL(c)
+	if err != nil {
+		return nil, err
+	}
+	return []string{u}, nil
 }


### PR DESCRIPTION
This adds the `git remote show -n` subcommand, as well as `remote get-url`.