### PR TITLE
Fix show-ref when commit not present locally

### DIFF
--- a/git/showref.go
+++ b/git/showref.go
@@ -109,7 +109,10 @@ func ShowRef(c *Client, opts ShowRefOptions, patterns []string) ([]Ref, error) {
 				}
 				refname := strings.TrimPrefix(path, c.GitDir.String())
 				ref, err := parseRef(c, refname)
-				if err != nil {
+				if err != nil && err != InvalidCommit {
+					// Invalid commit can just mean we don't
+					// have a local copy of the commit, so
+					// we don't care for the purpose of show-ref
 					return err
 				}
 				if len(patterns) == 0 {


### PR DESCRIPTION
If a commit was not present in the local object cache, show-ref
(and commands that depend on it such as fetch) would fail with
an "Invalid Commit" error. The fact that the commit is not
locally present should not be considered an error when showing
references.