### PR TITLE
Skip the vendor directories with the formatter check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
     - GOOS=plan9 go build
     - GOOS=windows go build
     - pwd
-    - diff -u <(echo -n) <(gofmt -d ./)
+    - diff -u <(echo -n) <(gofmt -d cmd git *.go)
     - go test -v ./...
     - chmod u+x ./go-get-tests.sh
     - ./go-get-tests.sh


### PR DESCRIPTION
It seems that there was a change to the go formatter that is tripping up on one fo the vendored libraries. This focuses the formatter checks on the project's own source code.