### PR TITLE
Add NetBSD support for ctime and inode syscalls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go_import_path: github.com/driusan/dgit
 
 script:
     - GOOS=darwin go build
+    - GOOS=netbsd go build
     - GOOS=plan9 go get ./...
     - GOOS=plan9 go build
     - GOOS=windows go build

--- a/git/file_ctime_netbsd.go
+++ b/git/file_ctime_netbsd.go
@@ -1,0 +1,17 @@
+// +build netbsd
+
+package git
+
+import (
+	"syscall"
+)
+
+func (f File) CTime() (uint32, uint32) {
+	stat, err := f.Lstat()
+	if err != nil {
+		return 0, 0
+	}
+	rawstat := stat.Sys().(*syscall.Stat_t)
+	tspec := rawstat.Ctimespec
+	return uint32(tspec.Sec), uint32(tspec.Nsec)
+}

--- a/git/file_ctime_other.go
+++ b/git/file_ctime_other.go
@@ -2,6 +2,7 @@
 // +build !darwin
 // +build !linux
 // +build !openbsd
+// +build !netbsd
 
 package git
 

--- a/git/file_inode_other.go
+++ b/git/file_inode_other.go
@@ -2,6 +2,7 @@
 // +build !darwin
 // +build !linux
 // +build !openbsd
+// +build !netbsd
 
 package git
 

--- a/git/file_inode_unix.go
+++ b/git/file_inode_unix.go
@@ -1,4 +1,4 @@
-// +build dragonfly linux openbsd
+// +build dragonfly linux openbsd netbsd
 
 package git
 


### PR DESCRIPTION
NetBSD supports ctime but the struct field is slightly different - this adds a new file_ctime_netbsd.go and updates the build tags accordingly. Also, NetBSD was not included in file_inode_unix.go, but it supports the inode field without issue.

I've build and run this version on a 64-bit version of NetBSD 8.0 and it worked. You can of course test that it compiles by setting GOOS=netbsd as you normally would for cross-compilation. 