### PR TITLE
Add "git fetch remote refspec" support

### DIFF
--- a/git/fetch.go
+++ b/git/fetch.go
@@ -2,39 +2,63 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
 type FetchOptions struct {
 	FetchPackOptions
+
+	Force bool
 }
 
-func Fetch(c *Client, opts FetchOptions, rmt Remote) error {
-	opts.FetchPackOptions.All = true
+// Fetch implements the "git fetch" command, fetching  refs from rmt.
+// If refs is nil, all remote refs will be fetched from the remote.
+func Fetch(c *Client, opts FetchOptions, rmt Remote, refs []RefSpec) error {
+	opts.FetchPackOptions.All = (refs == nil)
 	opts.FetchPackOptions.Verbose = true
-	newrefs, err := FetchPack(c, opts.FetchPackOptions, rmt, nil)
+
+	var wants []Refname
+	for _, ref := range refs {
+		wants = append(wants, ref.Src())
+	}
+	newrefs, err := FetchPack(c, opts.FetchPackOptions, rmt, wants)
 	if err != nil {
+		if err.Error() == "Already up to date." {
+			return nil
+		}
 		return err
 	}
-	for _, ref := range newrefs {
-		if c.GitDir != "" {
-			if strings.HasPrefix(ref.Name, "refs/heads") {
-				// FIXME: This should use update ref and also
-				// print a better message.
-				os.MkdirAll(c.GitDir.File(File("refs/remotes/"+rmt.String())).String(), 0755)
-				refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/"+rmt.String()+"/", 1)
-				refloc := fmt.Sprintf("%s/%s", c.GitDir, refname)
-				fmt.Printf("Creating %s with %s\n", refloc, ref.Value)
-				ioutil.WriteFile(
-					refloc,
-					[]byte(ref.Value.String()+"\n"),
-					0644,
-				)
+	if refs == nil {
+		// Fake a refspec if one wasn't specified so that things to
+		// to the default location under refs.
+		refs = append(
+			refs,
+			RefSpec(fmt.Sprintf("refs/heads/*:refs/remotes/%s/*", rmt)),
+		)
+	}
+	if c.GitDir != "" {
+		for _, ref := range newrefs {
+			for _, spec := range refs {
+				if match, dst := ref.MatchesRefSpecSrc(spec); match {
+					if !dst.Exists(c) {
+						fmt.Printf("[new branch] %v", dst)
+					} else {
+						fmt.Printf("%v %v", ref.Value, dst)
+					}
+					err := UpdateRef(
+						c,
+						UpdateRefOptions{NoDeref: true},
+						string(dst),
+						CommitID(ref.Value),
+						"Ref updated by fetch",
+					)
+					if err != nil {
+						// FIXME: I don't think we should be
+						// erroring out here.
+						return err
+					}
+				}
 			}
 		}
 	}
-
 	return nil
 }

--- a/git/fetchpack.go
+++ b/git/fetchpack.go
@@ -12,6 +12,11 @@ import (
 
 type Refname string
 
+// returns true if the reference name exists under the client's GitDir.
+func (rn Refname) Exists(c *Client) bool {
+	return c.GitDir.File(File(rn)).Exists()
+}
+
 type FetchPackOptions struct {
 	All                            bool
 	Stdin                          io.Reader

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -440,12 +440,18 @@ func buildLsRefsCmdV2(opts LsRemoteOptions, patterns []string) (string, error) {
 		prefixes := []string{"", "refs/", "refs/heads/", "refs/tags/", "refs/remotes/"}
 		// FIXME: Do better
 		for _, p := range patterns {
+			// If there was a * at the end it's a wildcard.
+			if p[len(p)-1] == '*' {
+				p = p[:len(p)-2]
+			}
 			for _, prefix := range prefixes {
 				penc, err := PktLineEncode([]byte("ref-prefix " + prefix + p))
 				if err != nil {
 					return "", err
 				}
+				log.Println(penc)
 				cmd += penc
+
 			}
 		}
 	}

--- a/git/pull.go
+++ b/git/pull.go
@@ -8,7 +8,7 @@ type PullOptions struct {
 }
 
 func Pull(c *Client, opts PullOptions, repository Remote, remotebranches []string) error {
-	err := Fetch(c, opts.FetchOptions, repository)
+	err := Fetch(c, opts.FetchOptions, repository, nil)
 	if err != nil && err.Error() != "Already up to date." {
 		// If fetch says we have all the refs, that doesn't
 		// mean that they're merged into the current branch

--- a/git/refspec.go
+++ b/git/refspec.go
@@ -19,6 +19,45 @@ func (r RefSpec) String() string {
 	return strings.TrimSpace(strings.TrimSuffix(string(r), "\000"))
 }
 
+// Src represents the ref name of the ref at the remote location for a refspec.
+// for instance, in the refspec "refs/heads/foo:refs/remotes/origin/foo",
+// src refers to refs/heads/foo, the name of the remote reference, while dst
+// refers to refs/remotes/origin/master, the location that we store our cache
+// of what that remote reference is.
+func (r RefSpec) Src() Refname {
+	if len(r) < 1 {
+		return ""
+	}
+
+	if r[0] == '+' {
+		r = r[1:]
+	}
+	if pos := strings.Index(string(r), ":"); pos >= 0 {
+		return Refname(r[:pos])
+	}
+
+	// There was no ":", so we just take the name.
+	return Refname(r)
+}
+
+// Dst represents the local destination of a remote ref in a refspec.
+// For instance, in the refspec "refs/heads/foo:refs/remotes/origin/foo",
+// Dst refers to "refs/remotes/origin/foo". If the refspec does not have an
+// explicit Dst specified, Dst returns an empty refname.
+func (r RefSpec) Dst() Refname {
+	if len(r) < 1 {
+		return ""
+	}
+
+	if r[0] == '+' {
+		r = r[1:]
+	}
+	if pos := strings.Index(string(r), ":"); pos >= 0 {
+		return Refname(r[pos+1:])
+	}
+	return ""
+}
+
 func (r RefSpec) HasPrefix(s string) bool {
 	return strings.HasPrefix(r.String(), s)
 }

--- a/git/refspec_test.go
+++ b/git/refspec_test.go
@@ -1,0 +1,48 @@
+package git
+
+import (
+	"testing"
+)
+
+func TestRefSpecParsing(t *testing.T) {
+	tests := []struct {
+		test    RefSpec
+		wantSrc Refname
+		wantDst Refname
+	}{
+		{
+			"refs/heads/foo",
+			"refs/heads/foo",
+			"",
+		},
+		{
+			"+refs/heads/foo",
+			"refs/heads/foo",
+			"",
+		},
+		{
+			"refs/heads/foo:refs/remotes/origin/foo",
+			"refs/heads/foo",
+			"refs/remotes/origin/foo",
+		},
+		{
+			"+refs/heads/foo:refs/remotes/origin/foo",
+			"refs/heads/foo",
+			"refs/remotes/origin/foo",
+		},
+		{
+			// XXX: Determine if this is a reasonable thing to do.
+			"refs/heads/*:refs/remotes/origin/*",
+			"refs/heads/*",
+			"refs/remotes/origin/*",
+		},
+	}
+	for i, tc := range tests {
+		if got := tc.test.Src(); got != tc.wantSrc {
+			t.Errorf("Test %d: unexpected Src for %v. got %v want %v", i, tc.test, got, tc.wantSrc)
+		}
+		if got := tc.test.Dst(); got != tc.wantDst {
+			t.Errorf("Test %d: unexpected Dst for %v. got %v want %v", i, tc.test, got, tc.wantDst)
+		}
+	}
+}


### PR DESCRIPTION
Add initial support for passing a refspec on the command line
to "git fetch".

This adds support for one of the formats of "git fetch" which
is invoked by Go when working outside of $GOPATH in go modules
mode.