### PR TITLE
Make GitDir.Create() create parent directory

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -215,7 +215,14 @@ func (gd GitDir) Open(f File) (*os.File, error) {
 // Creates a file relative to GitDir. There should not be
 // a leading slash.
 func (gd GitDir) Create(f File) (*os.File, error) {
-	return os.Create(gd.String() + "/" + f.String())
+	fpath := filepath.Join(gd.String(), f.String())
+	dir := File(filepath.Dir(fpath))
+	if !dir.Exists() {
+		if err := os.MkdirAll(dir.String(), 0755); err != nil {
+			return nil, err
+		}
+	}
+	return os.Create(fpath)
 }
 
 // ResetWorkTree will replace all objects in c.WorkDir with the content from

--- a/main.go
+++ b/main.go
@@ -97,6 +97,10 @@ func main() {
 		}
 	}
 	c, err := git.NewClient(*gitdir, *workdir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
 	// Pass any local configuration values to the client
 	for _, config := range configs {
 		parts := strings.Split(config, "=")

--- a/main.go
+++ b/main.go
@@ -97,10 +97,6 @@ func main() {
 		}
 	}
 	c, err := git.NewClient(*gitdir, *workdir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
-		os.Exit(1)
-	}
 	// Pass any local configuration values to the client
 	for _, config := range configs {
 		parts := strings.Split(config, "=")


### PR DESCRIPTION
This updates c.GitDir.Create() to create the parent directory of the
file if it doesn't exist, similarly to how File.Create does.

This serves 2 purposes:

1.  Make the 2 create functions symmetrical
2.  Causes UpdateRef (which uses GitDir.Create()) to create 
    the parent directory

Without this change, if you do "git remote add something; git fetch
something" it fetches all the objects from remote "something", and
then crashes with an error about the parent directory 
`refs/remotes/something` not existing before creating the references.