### PR TITLE
Fix ls-tree (and dependent commands) in bare mode

### DIFF
--- a/cmd/lstree.go
+++ b/cmd/lstree.go
@@ -57,7 +57,7 @@ func LsTree(c *git.Client, args []string) error {
 	for _, entry := range tree {
 		var lineend string
 		var name string
-		if opts.FullName || opts.FullTree {
+		if opts.FullName || opts.FullTree || c.IsBare() {
 			name = entry.PathName.String()
 		} else {
 			rname, err := entry.PathName.FilePath(c)

--- a/git/client.go
+++ b/git/client.go
@@ -130,6 +130,11 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// Returns true if the repo is a bare repo.
+func (c *Client) IsBare() bool {
+	return c.GetConfig("core.bare") == "true"
+}
+
 // Walks from the current directory to find a .git directory
 func findGitDir() GitDir {
 	startPath, err := os.Getwd()

--- a/git/lstree.go
+++ b/git/lstree.go
@@ -41,6 +41,9 @@ func LsTree(c *Client, opts LsTreeOptions, tree Treeish, paths []File) ([]*Index
 	// which match the directories of paths, but first check if we're
 	// in the root of the workgir (or using FullTree), in which case we
 	// can just use the tree passed.
+	if c.GetConfig("core.bare") == "true" {
+		opts.FullTree = true
+	}
 	if opts.FullTree {
 		return lsTree(c, opts, tree, "", paths)
 	}

--- a/git/lstree.go
+++ b/git/lstree.go
@@ -41,7 +41,7 @@ func LsTree(c *Client, opts LsTreeOptions, tree Treeish, paths []File) ([]*Index
 	// which match the directories of paths, but first check if we're
 	// in the root of the workgir (or using FullTree), in which case we
 	// can just use the tree passed.
-	if c.GetConfig("core.bare") == "true" {
+	if c.IsBare() {
 		opts.FullTree = true
 	}
 	if opts.FullTree {


### PR DESCRIPTION
LsTree tries to only display things that are relative
to the current working directory. In a bare repo, this
matches nothing, because there is no working directory.

This causes commands that depend on LsTree (such as archive,
as used by go in module mode) to fail in bare repos.