### PR TITLE
Do not chdir while doing an init

### DIFF
--- a/git/commit_test.go
+++ b/git/commit_test.go
@@ -130,6 +130,9 @@ func TestUnmergedCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chdir(gitdir); err != nil {
+		t.Fatal(err)
+	}
 	idx := NewIndex()
 	idx.Objects = []*IndexEntry{
 		&IndexEntry{

--- a/git/init.go
+++ b/git/init.go
@@ -121,20 +121,6 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 		}
 	}
 
-	// Now go into the directory and adjust workdir and gitdir so that
-	// tests are in the right place.
-	if !opts.Bare {
-		if err := os.Chdir(c.WorkDir.String()); err != nil {
-			return c, err
-		}
-		wd, err := os.Getwd()
-		if err != nil {
-			return c, err
-		}
-		c.WorkDir = WorkDir(wd)
-		c.GitDir = GitDir(wd + "/.git")
-	}
-
 	if opts.Template != "" {
 		err := filepath.Walk(opts.Template.String(), func(path string, info os.FileInfo, err error) error {
 			if err != nil {


### PR DESCRIPTION
This was only done so that tests were run in
the right directory, but tests should be the
ones doing the Chdir themselves. Changing
the directory causes paths to be evaluated
relative to the wrong directory when handling
user input after an init, such as while doing
a clone.