### PR TITLE
Do not chdir while doing an init, again

### DIFF
--- a/git/clone.go
+++ b/git/clone.go
@@ -139,6 +139,9 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 	if err := c.GitDir.WriteFile("logs/HEAD", reflog, 0755); err != nil {
 		return err
 	}
+	if opts.Bare {
+		return nil
+	}
 
 	// Finally, checkout the files. Since it's an initial clone, we just
 	// do a hard reset and don't try to be intelligent about what readtree

--- a/git/commit_test.go
+++ b/git/commit_test.go
@@ -130,6 +130,9 @@ func TestUnmergedCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := os.Chdir(gitdir); err != nil {
+		t.Fatal(err)
+	}
 	idx := NewIndex()
 	idx.Objects = []*IndexEntry{
 		&IndexEntry{

--- a/git/remote.go
+++ b/git/remote.go
@@ -75,6 +75,11 @@ func (r Remote) IsStateless(c *Client) (bool, error) {
 	return strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://"), nil
 }
 
+// Returns true if the remote points to a local filesystem path.
+func (r Remote) IsFile() bool {
+	return strings.HasPrefix(r.String(), "file://") || File(r.String()).Exists()
+}
+
 // Gets a list of local references cached for this Remote
 func (r Remote) GetLocalRefs(c *Client) ([]Ref, error) {
 	allrefs, err := ShowRef(c, ShowRefOptions{}, nil)

--- a/git/reset.go
+++ b/git/reset.go
@@ -121,7 +121,10 @@ func ResetMode(c *Client, opts ResetOptions, cmt Commitish) error {
 		return err
 	}
 	if opts.Mixed || opts.Hard {
-		idx, err := ReadTree(c, ReadTreeOptions{Reset: true, Update: true}, comm)
+		// If it's a hard reset, don't bother with -reset or -u, because
+		// it'll be handled by the CheckoutIndexUncommited below and
+		// we don't want to checkout twice.
+		idx, err := ReadTree(c, ReadTreeOptions{Reset: !opts.Hard, Update: !opts.Hard}, comm)
 		if err != nil {
 			return err
 		}

--- a/git/reset.go
+++ b/git/reset.go
@@ -121,10 +121,7 @@ func ResetMode(c *Client, opts ResetOptions, cmt Commitish) error {
 		return err
 	}
 	if opts.Mixed || opts.Hard {
-		// If it's a hard reset, don't bother with -reset or -u, because
-		// it'll be handled by the CheckoutIndexUncommited below and
-		// we don't want to checkout twice.
-		idx, err := ReadTree(c, ReadTreeOptions{Reset: !opts.Hard, Update: !opts.Hard}, comm)
+		idx, err := ReadTree(c, ReadTreeOptions{Reset: true, Update: true}, comm)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This was only done so that tests were run in the right directory,
but tests should be the ones doing the Chdir themselves. Changing
the directory causes paths to be evaluated relative to the wrong
directory when handling user input after an init, such as while
doing a clone.

However, the reset command invoked from of a clone needs to be able
to make paths relative.  As result, we still need to chdir within
clone, but restore it for the caller after we're done.