### PR TITLE
Add more options to rev-parse

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -135,6 +135,37 @@ func (c *Client) IsBare() bool {
 	return c.GetConfig("core.bare") == "true"
 }
 
+// Returns true if the path is under the client's GitDir.
+func (c *Client) IsInsideGitDir(path File) bool {
+	abs, err := filepath.Abs(path.String())
+	if err != nil {
+		panic(err)
+	}
+	absgd, err := filepath.Abs(c.GitDir.String())
+	if err != nil {
+		panic(err)
+	}
+	return strings.HasPrefix(abs, absgd)
+}
+
+// Returns true if path is inside of the client's work tree.
+func (c *Client) IsInsideWorkTree(path File) bool {
+	if c.IsBare() || c.IsInsideGitDir(path) {
+		return false
+	}
+
+	abs, err := filepath.Abs(path.String())
+	if err != nil {
+		panic(err)
+	}
+	abswt, err := filepath.Abs(c.WorkDir.String())
+	if err != nil {
+		panic(err)
+	}
+	return strings.HasPrefix(abs, abswt)
+
+}
+
 // Walks from the current directory to find a .git directory
 func findGitDir() GitDir {
 	startPath, err := os.Getwd()

--- a/git/revparse.go
+++ b/git/revparse.go
@@ -87,17 +87,11 @@ type RevParseOptions struct {
 	// Options for Files
 	// BUG(driusan): These should be handled as part of "args", not in RevParseOptions.
 	// They're included here so that I don't forget about them.
-	GitDir           GitDir
-	GitCommonDir     GitDir
-	IsInsideGitDir   bool
-	IsInsideWorkTree bool
-	IsBareRepository bool
-	ResolveGitDir    File // path
-	GitPath          GitDir
-	ShowCDup         bool
-	ShowPrefix       bool
-	ShowToplevel     bool
-	SharedIndexPath  bool
+	GitCommonDir    GitDir
+	ResolveGitDir   File // path
+	GitPath         GitDir
+	ShowCDup        bool
+	SharedIndexPath bool
 
 	// Other options
 	After, Before time.Time
@@ -363,6 +357,47 @@ func RevParse(c *Client, opt RevParseOptions, args []string) (commits []ParsedRe
 			} else {
 				fmt.Printf("%s\n", c.GitDir)
 			}
+		case "--is-inside-git-dir":
+			if c.IsInsideGitDir(".") {
+				fmt.Printf("true\n")
+			} else {
+				fmt.Printf("false\n")
+			}
+		case "--is-inside-work-tree":
+			if c.IsInsideWorkTree(".") {
+				fmt.Printf("true\n")
+			} else {
+				fmt.Printf("false\n")
+			}
+		case "--is-bare-repository":
+			if c.IsBare() {
+				fmt.Printf("true\n")
+			} else {
+				fmt.Printf("false\n")
+			}
+		case "--show-toplevel":
+			absgd, err := filepath.Abs(c.WorkDir.String())
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				continue
+			}
+			fmt.Println(absgd)
+		case "--show-prefix":
+			if c.IsBare() {
+				fmt.Println("")
+				continue
+			}
+			absgd, err := filepath.Abs(c.WorkDir.String())
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				continue
+			}
+			pwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				continue
+			}
+			fmt.Println(strings.TrimPrefix(pwd, absgd+"/") + "/")
 		case "--verify":
 			// FIXME: Implement this properly. This is just to prevent default
 			// from outputing the string '--verify'

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	workdir := flag.String("work-tree", "", "specify the working directory of git")
-	gitdir := flag.String("git-dir", os.Getenv("GIT_DIR"), "specify the repository of git")
+	gitdir := flag.String("git-dir", "", "specify the repository of git")
 	dir := flag.String("C", "", "chdir before starting git")
 	superprefix := flag.String("super-prefix", "", "useless option used internally by git test suite")
 	configs := []string{}
@@ -95,6 +95,9 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	}
+	if *gitdir != "" {
+		os.Setenv("GIT_DIR", *gitdir)
 	}
 	c, err := git.NewClient(*gitdir, *workdir)
 	// Pass any local configuration values to the client

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	workdir := flag.String("work-tree", "", "specify the working directory of git")
-	gitdir := flag.String("git-dir", "", "specify the repository of git")
+	gitdir := flag.String("git-dir", os.Getenv("GIT_DIR"), "specify the repository of git")
 	dir := flag.String("C", "", "chdir before starting git")
 	superprefix := flag.String("super-prefix", "", "useless option used internally by git test suite")
 	configs := []string{}

--- a/official-git/run-tests.sh
+++ b/official-git/run-tests.sh
@@ -76,6 +76,7 @@ make t0000-basic.sh \
         t1304-default-acl.sh \
         t1308-config-set.sh \
         t1403-show-ref.sh \
+        t1500-rev-parse.sh \
         t2000-checkout-cache-clash.sh \
         t2001-checkout-cache-clash.sh \
         t2002-checkout-cache-u.sh \


### PR DESCRIPTION
This adds some of the non-revision-parsing related command line
arguments to rev-parse used by t1500-revparse in the official git
test suite. It handles the --is-inside-git-dir, --is-inside-work-tree,
--is-bare-repository, --show-toplevel, and --show-prefix command
line options.