### PR TITLE
Add commit variant where files are directly specified

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -118,7 +118,12 @@ func Commit(c *git.Client, args []string) (string, error) {
 		finalMessage = string(m2)
 	}
 
-	cmt, err := git.Commit(c, opts, git.CommitMessage(finalMessage), nil)
+	filesStr := flags.Args()
+	var files []git.File
+	for _, f := range filesStr {
+		files = append(files, git.File(f))
+	}
+	cmt, err := git.Commit(c, opts, git.CommitMessage(finalMessage), files)
 	switch err {
 	case git.NoGlobalConfig:
 		committer, _ := c.GetCommitter(nil)

--- a/git/writetree.go
+++ b/git/writetree.go
@@ -17,7 +17,10 @@ func WriteTree(c *Client, opts WriteTreeOptions) (TreeID, error) {
 	if err != nil {
 		return TreeID{}, err
 	}
+	return WriteTreeFromIndex(c, idx, opts)
+}
 
+func WriteTreeFromIndex(c *Client, idx *Index, opts WriteTreeOptions) (TreeID, error) {
 	objs := idx.Objects
 	if opts.Prefix != "" {
 		opts.Prefix = strings.TrimRight(opts.Prefix, "/")


### PR DESCRIPTION
This adds the variant of git commit where you run
"git commit file1 file2..."

It's not a very robust or well-tested implementation, but does just
enough to ensure that the setup of rev-parse-verify tests from the
official git test suite succeeds.