### PR TITLE
Add basic git fsck command

### DIFF
--- a/cmd/fsck.go
+++ b/cmd/fsck.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/driusan/dgit/git"
+)
+
+func Fsck(c *git.Client, args []string) error {
+	flags := newFlagSet("fsck")
+	opts := git.FsckOptions{}
+
+	flags.BoolVar(&opts.Unreachable, "unreachable", false, "Print unreachable objects")
+	nodangling := flags.Bool("no-dangling", false, "Do not print dangling objects")
+	dangling := flags.Bool("dangling", false, "Print dangling objects (default)")
+	flags.BoolVar(&opts.Root, "root", false, "Report root nodes")
+	flags.BoolVar(&opts.Tags, "tags", false, "Report tags")
+	flags.BoolVar(&opts.Cache, "cache", false, "Consider objects in the index as a head node for unreachability traces")
+	flags.BoolVar(&opts.NoReflogs, "no-reflogs", false, "Do not consider commits only reachable from reflogs reachable")
+	full := flags.Bool("full", false, "Do not just check GIT_OBJECT_DIRECTORY, but also alternates")
+	nofull := flags.Bool("no-full", false, "Disable --full")
+	flags.BoolVar(&opts.ConnectivityOnly, "connectivity-only", false, "Only check the connectivity of commits, not the integrity of blobs")
+	flags.BoolVar(&opts.Strict, "strict", false, "Check for files with mode g+w bit set")
+	flags.BoolVar(&opts.Verbose, "verbose", false, "Be chatty")
+	flags.BoolVar(&opts.LostFound, "lost-found", false, "Write dangling objects into .git/lost-found")
+	flags.BoolVar(&opts.NameObjects, "name-objects", false, "When displaing names of reachable objects,  also display a name describing how they are reachable compatible with rev-parse")
+
+	noprogress := flags.Bool("no-proress", false, "Do not print progress information")
+	progress := flags.Bool("progress", false, "Print progress information (default)")
+
+	flags.Parse(args)
+
+	if *nodangling && *dangling {
+		return fmt.Errorf("Can not specify both --dangling and --no-dangling")
+	} else if *nodangling {
+		opts.NoDangling = true
+	} else if *dangling {
+		opts.NoDangling = false
+	}
+
+	if *noprogress && *progress {
+		return fmt.Errorf("Can not specify both --progress and --no-progress")
+	} else if *noprogress {
+		opts.NoProgress = true
+	} else if *progress {
+		opts.NoProgress = false
+	}
+
+	if *nofull && *full {
+		return fmt.Errorf("Can not specify both --full and --no-full")
+	} else if *nofull {
+		opts.NoFull = true
+	} else if *full {
+		opts.NoFull = false
+	}
+
+	objects := flags.Args()
+
+	// We disregard errs because they've already been printed,
+	// they were just returned in case someone wants to use git.Fsck
+	// as an API.
+	// However, this (cmd.Fsck) still returns an error in case of
+	// bad argument parsing.
+	errs := git.Fsck(c, os.Stderr, opts, objects)
+	if len(errs) > 0 {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/git/client.go
+++ b/git/client.go
@@ -418,7 +418,8 @@ func (c *Client) GetAuthor(t *time.Time) Person {
 }
 
 // Returns the author that should be used for a commit message.
-// If time t is provided,
+// If time t is provided, it will return a person with the time
+// part populated to t.
 func (c *Client) GetCommitter(t *time.Time) (Person, error) {
 	person := Person{}
 	name := os.Getenv("GIT_COMMITTER_NAME")
@@ -658,4 +659,12 @@ func (c *Client) GetConfig(varname string) string {
 		return val
 	}
 	return ""
+}
+
+// Returns the .git/objects directory.
+func (c *Client) GetObjectsDir() File {
+	if objdir := os.Getenv("GIT_OBJECT_DIRECTORY"); objdir != "" {
+		return File(objdir)
+	}
+	return c.GitDir.File("objects")
 }

--- a/git/fsck.go
+++ b/git/fsck.go
@@ -1,0 +1,316 @@
+package git
+
+import (
+	"compress/zlib"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type FsckOptions struct {
+	Unreachable      bool
+	NoDangling       bool
+	Root             bool
+	Tags             bool
+	Cache            bool
+	NoReflogs        bool
+	NoFull           bool
+	ConnectivityOnly bool
+	Strict           bool
+	Verbose          bool
+	LostFound        bool
+	NameObjects      bool
+	NoProgress       bool
+}
+
+// Fsck implements the "git fsck" subcommand. It prints any error encountered to
+// the stderr argument, and returns an array of said errors.
+func Fsck(c *Client, stderr io.Writer, opts FsckOptions, objects []string) (errs []error) {
+	addErr := func(err error) {
+		fmt.Fprintln(stderr, err)
+		errs = append(errs, err)
+
+	}
+
+	if err := verifyHead(c, stderr, opts); err != nil {
+		addErr(err)
+	}
+
+	if opts.Verbose {
+		fmt.Fprintln(stderr, "Checking object directory")
+	}
+
+	// HaveObject doesn't do any validation, so we keep track of things
+	// we found that are corrupted so we can include error messages if
+	// they're used.
+	corrupted := make(map[Sha1]struct{})
+	objdir := c.GetObjectsDir().String()
+	objprefixes, err := ioutil.ReadDir(objdir)
+	if err != nil {
+		addErr(err)
+	} else {
+		// FIXME: This should verify the hashes in pack indexes too.
+		for _, prefixdir := range objprefixes {
+			// We wrap the loop in a closure function so that defers
+			// (ie file.Close()) don't need to wait until the entire repo
+			// is finished.
+			err := func() error {
+				// We only want the 2 character prefix directories so that we
+				// can check the objects inside of them.
+				if !prefixdir.IsDir() {
+					return nil
+				}
+				if len(prefixdir.Name()) != 2 {
+					return nil
+				}
+				objects, err := ioutil.ReadDir(
+					filepath.Join(objdir, prefixdir.Name()),
+				)
+				if err != nil {
+					return err
+				}
+				for _, object := range objects {
+					wantsha1 := fmt.Sprintf("%s%s", prefixdir.Name(), object.Name())
+					oid, err := Sha1FromString(wantsha1)
+					if err != nil {
+						return err
+					}
+					if opts.Verbose {
+						fmt.Fprintf(stderr, "Checking %s %s\n", oid.Type(c), wantsha1)
+					}
+					filename := filepath.Join(objdir, prefixdir.Name(), object.Name())
+					f, err := os.Open(filepath.Join(filename))
+					if err != nil {
+						return err
+					}
+					defer f.Close()
+					zr, err := zlib.NewReader(f)
+					if err != nil {
+						return err
+					}
+					h := sha1.New()
+					if _, err := io.Copy(h, zr); err != nil {
+						return err
+					}
+					sum := h.Sum(nil)
+					sumsha1, err := Sha1FromSlice(sum)
+					if err != nil {
+						// This should never happen, a sha1 from crypto/sha1
+						// should always be convertable to our Sha1 type
+						panic(err)
+					}
+					if sumsha1 != oid {
+						corrupted[oid] = struct{}{}
+						return fmt.Errorf("hash mismatch for %v (expected %v)", filename, oid)
+					}
+				}
+				return nil
+			}()
+			if err != nil {
+				addErr(err)
+			}
+		}
+	}
+
+	var hc []Commitish
+	// Either use RevParse or ShowRef to get a list of all commits that
+	// we want to be checking, depending on if anything was passed as
+	// an argument.
+	if len(objects) != 0 {
+		heads, err := RevParse(c, RevParseOptions{}, objects)
+		if err != nil {
+			addErr(err)
+			// We can't do much more if we can't figure out which objects
+			// we're supposed to be validating.
+			return errs
+		}
+		for _, head := range heads {
+			h, err := head.CommitID(c)
+			if err != nil {
+				addErr(err)
+			}
+			hc = append(hc, h)
+		}
+	} else {
+		heads, err := ShowRef(c, ShowRefOptions{}, nil)
+		if err != nil {
+			addErr(err)
+		}
+		for _, head := range heads {
+			h, err := head.CommitID(c)
+			if err != nil {
+				addErr(fmt.Errorf("not a commit"))
+			}
+			hc = append(hc, h)
+		}
+
+	}
+
+	// Get a list of all reachable objects from the heads.
+	reachables, err := RevList(c, RevListOptions{Quiet: true, Objects: true}, nil, hc, nil)
+	if err != nil {
+		errs = append(errs, err)
+		return errs
+	}
+	for _, obj := range reachables {
+		if opts.Verbose {
+			fmt.Printf("Checking %v\n", obj)
+		}
+		if _, ok := corrupted[obj]; ok {
+			addErr(fmt.Errorf("%v corrupt or missing", obj))
+			continue
+		}
+		o, _, err := c.HaveObject(obj)
+		if err != nil {
+			addErr(err)
+			continue
+		}
+		if !o {
+			addErr(fmt.Errorf("%v corrupt or missing", obj))
+			continue
+		}
+
+		switch ty := obj.Type(c); ty {
+		case "commit":
+			if err := verifyCommit(c, opts, CommitID(obj)); err != nil {
+				addErr(fmt.Errorf("error in commit %v: %v", obj, err))
+			}
+		case "tree":
+			if err := verifyTree(c, opts, TreeID(obj)); err != nil {
+				addErr(err)
+			}
+		case "blob":
+			// There's not much to verify for a blob, but it's
+			// a known type.
+		default:
+			addErr(fmt.Errorf("Unknown object type %v", ty))
+		}
+	}
+	return errs
+}
+
+// Verifies the HEAD pointer for fsck.
+func verifyHead(c *Client, stderr io.Writer, opts FsckOptions) error {
+	if opts.Verbose {
+		fmt.Fprintln(stderr, "Checking HEAD link")
+	}
+
+	hfile := c.GitDir.File("HEAD")
+	if !hfile.Exists() {
+		return fmt.Errorf("Missing head link")
+	}
+
+	line, err := hfile.ReadFirstLine()
+	if err != nil {
+		// this shouldn't happen since we already verified it exists
+		return err
+	}
+
+	sha1, err := Sha1FromString(line)
+	if err != nil {
+		// we couldn't convert it to a sha1, so it must be a ref
+		// pointer and should point to a head (not a tag or a remote)
+		if !strings.HasPrefix(line, "ref: refs/heads") {
+			return fmt.Errorf("error: HEAD points to something strange")
+		}
+		return nil
+	}
+
+	// We could convert the line to a Sha1, it's a detached head.
+	if sha1 == (Sha1{}) {
+		return fmt.Errorf("error: HEAD: detached HEAD points at nothing")
+	}
+	have, _, err := c.HaveObject(sha1)
+	if err != nil || !have {
+		return fmt.Errorf("error: invalid sha1 pointer %v", sha1)
+	}
+	return nil
+}
+
+// Verifies a commit for fsck or rev-parse --verify-objects
+func verifyCommit(c *Client, opts FsckOptions, cmt CommitID) error {
+	obj, err := c.GetCommitObject(cmt)
+	if err != nil {
+		return err
+	}
+
+	validatePerson := func(typ string) error {
+		s := obj.GetHeader(typ)
+		// 0 = whole match
+		// 1 = name
+		// 2 = email
+		// 3 = timestamp
+		personRe := regexp.MustCompile(`(.*?)\<(.*?)\>(.*)`)
+		pieces := personRe.FindStringSubmatch(s)
+		if len(pieces) != 4 {
+			// This is mostly just to get the same error messages
+			// as git when running the official test suite"
+			// "foo asdf> 1234" is reported as bad name
+			// "foo 1234" is reported as bad email.
+			if strings.Count(s, ">") == 0 {
+				return fmt.Errorf("missingEmail: invalid %v line - missing email", typ)
+			}
+			return fmt.Errorf("badName: invalid %v line - bad name", typ)
+		}
+		if strings.Count(pieces[1], ">") > 0 {
+			return fmt.Errorf("badName: invalid %v line - bad name", typ)
+		}
+		//fmt.Printf(`"%v" "%v" "%v"`+"\n", pieces[1], pieces[2], pieces[3])
+		if !strings.HasPrefix(pieces[3], " ") {
+			return fmt.Errorf("missingSpaceBeforeDate: invalid %v line - missing space before date", typ)
+		}
+
+		timestampRe := regexp.MustCompile(`^ (\d+) (\+|\-)(\d+)$`)
+		timepieces := timestampRe.FindStringSubmatch(pieces[3])
+		if len(timepieces) == 0 {
+			return fmt.Errorf("invalidateDate: invalid %v line - timestamp is not a valid date")
+		}
+		// check for overflow of uint64
+		bignum, ok := new(big.Int).SetString(timepieces[1], 10)
+		if !ok {
+			// This shouldn't happen since the regexp validated
+			// that it was a string of digits.
+			panic("Could not convert integer to bignum")
+		}
+
+		// can't use math.Newint because it takes an int64, not a uint64
+		maxuint64, ok := new(big.Int).SetString("18446744073709551615", 10)
+		if !ok {
+			// This shouldn't happen since we're dealing with a const
+			panic("Could not convert max uint64 to bignum")
+		}
+		if bignum.Cmp(maxuint64) > 0 {
+			return fmt.Errorf("badDateOverflow: invalid %v line - date causes integer overflow", typ)
+		}
+		return nil
+	}
+	if err := validatePerson("author"); err != nil {
+		return err
+	}
+	if err := validatePerson("committer"); err != nil {
+		return err
+	}
+
+	content := obj.GetContent()
+	for i, c := range content {
+		if c == 0 {
+			return fmt.Errorf("nulInHeader: unterminated header: NUL at offset %v", i)
+		}
+		if c == '\n' && i > 0 && content[i-1] == '\n' {
+			// reached the end of the headers.
+			break
+		}
+	}
+	return nil
+}
+
+// Verifies a tree for fsck or rev-parse --verify-objects
+func verifyTree(c *Client, opts FsckOptions, tid TreeID) error {
+	return nil
+}

--- a/git/fsck.go
+++ b/git/fsck.go
@@ -261,7 +261,6 @@ func verifyCommit(c *Client, opts FsckOptions, cmt CommitID) error {
 		if strings.Count(pieces[1], ">") > 0 {
 			return fmt.Errorf("badName: invalid %v line - bad name", typ)
 		}
-		//fmt.Printf(`"%v" "%v" "%v"`+"\n", pieces[1], pieces[2], pieces[3])
 		if !strings.HasPrefix(pieces[3], " ") {
 			return fmt.Errorf("missingSpaceBeforeDate: invalid %v line - missing space before date", typ)
 		}

--- a/git/fsck.go
+++ b/git/fsck.go
@@ -269,7 +269,7 @@ func verifyCommit(c *Client, opts FsckOptions, cmt CommitID) error {
 		timestampRe := regexp.MustCompile(`^ (\d+) (\+|\-)(\d+)$`)
 		timepieces := timestampRe.FindStringSubmatch(pieces[3])
 		if len(timepieces) == 0 {
-			return fmt.Errorf("invalidateDate: invalid %v line - timestamp is not a valid date")
+			return fmt.Errorf("invalidateDate: invalid %v line - timestamp is not a valid date", typ)
 		}
 		// check for overflow of uint64
 		bignum, ok := new(big.Int).SetString(timepieces[1], 10)

--- a/git/updateindex.go
+++ b/git/updateindex.go
@@ -235,6 +235,5 @@ func UpdateIndexRefresh(c *Client, idx *Index, opts UpdateIndexOptions) (*Index,
 
 func UpdateIndexCacheInfo(c *Client, idx *Index, opts UpdateIndexOptions) (*Index, error) {
 	err := idx.AddStage(c, opts.CacheInfo.Path, opts.CacheInfo.Mode, opts.CacheInfo.Sha1, Stage0, 0, 0, opts)
-	fmt.Printf("%v err %v idx", err, idx)
 	return idx, err
 }

--- a/git/updateref.go
+++ b/git/updateref.go
@@ -8,7 +8,6 @@ import (
 )
 
 type UpdateRefOptions struct {
-	// Not implemented
 	Delete bool
 
 	NoDeref      bool
@@ -103,6 +102,13 @@ func UpdateRefSpec(c *Client, opts UpdateRefOptions, ref RefSpec, cmt CommitID, 
 func UpdateRef(c *Client, opts UpdateRefOptions, ref string, cmt CommitID, reason string) error {
 	if opts.Stdin != nil {
 		return fmt.Errorf("UpdateRef batch mode not implemented")
+	}
+
+	if opts.Delete {
+		// FIXME: This is more of a hack to ensure that the fsck passes
+		// than a real implementation.
+		f := c.GitDir.File(File(ref))
+		return f.Remove()
 	}
 
 	// It's not a symbolic ref, it's a real ref. Just directly call UpdateRefSpec

--- a/main.go
+++ b/main.go
@@ -462,6 +462,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case "fsck":
+		if err := cmd.Fsck(c, args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 	case "help":
 		flag.CommandLine.SetOutput(os.Stdout)
 		flag.Usage()


### PR DESCRIPTION
This adds a skeleton of the git fsck command. It passes the first 15 tests (looking for basic object corruption and verifying commits) from the official test suite.