### PR TITLE
Add support for GIT_INDEX_FILE environment variable

### DIFF
--- a/git/add.go
+++ b/git/add.go
@@ -126,7 +126,14 @@ func Add(c *Client, opts AddOptions, files []File) (*Index, error) {
 	}
 
 	if !opts.DryRun {
-		f, err := c.GitDir.Create(File("index"))
+		var f *os.File
+		var err error
+		if ifile := os.Getenv("GIT_INDEX_FILE"); ifile != "" {
+			f, err = os.Create(ifile)
+		} else {
+			f, err = c.GitDir.Create("index")
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/git/index.go
+++ b/git/index.go
@@ -189,7 +189,16 @@ func (ie *IndexEntry) RefreshStat(c *Client) error {
 // Reads the index file from the GitDir and returns a Index object.
 // If the index file does not exist, it will return a new empty Index.
 func (d GitDir) ReadIndex() (*Index, error) {
-	file, err := d.Open("index")
+	var file *os.File
+	var err error
+	if ifile := os.Getenv("GIT_INDEX_FILE"); ifile != "" {
+		log.Println("Using index file", ifile)
+		file, err = os.Open(ifile)
+	} else {
+
+		file, err = d.Open("index")
+	}
+
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Is the file doesn't exist, treat it
@@ -220,7 +229,11 @@ func (d GitDir) ReadIndex() (*Index, error) {
 	var idx uint32
 	indexes := make([]*IndexEntry, i.NumberIndexEntries, i.NumberIndexEntries)
 	for idx = 0; idx < i.NumberIndexEntries; idx += 1 {
-		if index, err := ReadIndexEntry(file, i.Version); err == nil {
+		index, err := ReadIndexEntry(file, i.Version)
+		if err != nil {
+			log.Println(err)
+		} else {
+			log.Println("Read entry for ", index.PathName)
 			indexes[idx] = index
 		}
 	}

--- a/git/readtree.go
+++ b/git/readtree.go
@@ -597,7 +597,10 @@ func checkReadtreePrereqs(c *Client, opt ReadTreeOptions, idx *Index) ([]File, e
 // Reads a tree into the index. If DryRun is not false, it will also be written
 // to disk.
 func ReadTree(c *Client, opt ReadTreeOptions, tree Treeish) (*Index, error) {
-	idx, _ := c.GitDir.ReadIndex()
+	idx, err := c.GitDir.ReadIndex()
+	if err != nil {
+		idx = NewIndex()
+	}
 	origMap := idx.GetMap()
 
 	resetremovals, err := checkReadtreePrereqs(c, opt, idx)


### PR DESCRIPTION
This adds minimal support for the GIT_INDEX_FILE environment
variable, which is used by some fsck tests.