### PR TITLE
 Fix bug where git rev-list could return the same object multiple times

### DIFF
--- a/git/revlist.go
+++ b/git/revlist.go
@@ -130,6 +130,7 @@ func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeL
 				return err
 			}
 			for _, o := range objs {
+                excludeList[o] = struct{}{}
 				if err := callback(o); err != nil {
 					return err
 				}

--- a/git/revlist.go
+++ b/git/revlist.go
@@ -130,7 +130,7 @@ func revListCallback(c *Client, opt RevListOptions, commits []CommitID, excludeL
 				return err
 			}
 			for _, o := range objs {
-                excludeList[o] = struct{}{}
+				excludeList[o] = struct{}{}
 				if err := callback(o); err != nil {
 					return err
 				}

--- a/git/sha1.go
+++ b/git/sha1.go
@@ -699,10 +699,16 @@ func (t TreeID) GetAllObjectsExcept(cl *Client, excludeList map[Sha1]struct{}, p
 		}
 		i += size
 
+		if excludeList != nil {
+			if _, ok := excludeList[entry.Sha1]; ok {
+				continue
+			}
+		}
 		val[IndexPath(name)] = entry
 
 		if entry.FileMode == ModeTree && recurse {
 			childTree := TreeID(entry.Sha1)
+
 			children, err := childTree.GetAllObjectsExcept(cl, excludeList, "", recurse, excludeself)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
A blob object could be included in the results of git rev-list multiple
times if it was in different tree objects. This improves the validation
for GetAllObjectsExcept to exclude blob objects as well.