### PR TITLE
UpdateRef for remote refspec on push

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -131,9 +131,10 @@ To push and set the upstream to the remote named "origin" use:
 	// We don't do anything special for setupstream here, because it was saved above
 	if rmtname := c.GetConfig(fmt.Sprintf("branch.%v.remote", bname)); rmtname != "" {
 		rmtref := git.RefSpec(fmt.Sprintf("refs/remotes/%v/%v", rmtname, bname))
-		if err := git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push"); err != nil {
-			return err
-		}
+		git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push")
+		// if git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push"); err != nil {
+		//	return err
+		//}
 	}
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -131,10 +131,9 @@ To push and set the upstream to the remote named "origin" use:
 	// We don't do anything special for setupstream here, because it was saved above
 	if rmtname := c.GetConfig(fmt.Sprintf("branch.%v.remote", bname)); rmtname != "" {
 		rmtref := git.RefSpec(fmt.Sprintf("refs/remotes/%v/%v", rmtname, bname))
-		git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push")
-		// if git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push"); err != nil {
-		//	return err
-		//}
+		if git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push"); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -127,5 +127,13 @@ To push and set the upstream to the remote named "origin" use:
 		RemoteSha1: remoteHead.String(),
 		Refname:    git.RefSpec(mergebranch),
 	}, f, stat.Size())
+
+	// We don't do anything special for setupstream here, because it was saved above
+	if rmtname := c.GetConfig(fmt.Sprintf("branch.%v.remote", bname)); rmtname != "" {
+		rmtref := git.RefSpec(fmt.Sprintf("refs/remotes/%v/%v", rmtname, bname))
+		if err := git.UpdateRefSpec(c, git.UpdateRefOptions{}, rmtref, git.CommitID(localSha[0].Id), "update by push"); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
When running git push, the ".git/refs/remotes/remotename/branch"
ref needs to be populated. Failing to do this on an initial push
(with --set-upstream set) means that future pushes (both with dgit
and git) fail, because it can't resolve the rev for the the refspec
"remotename/branch" that it has locally.