### PR TITLE
Use vanity import path in go get module test

### DIFF
--- a/go-get-modules-tests.sh
+++ b/go-get-modules-tests.sh
@@ -33,7 +33,7 @@ test -f $DGIT_TRACE || (echo "ERROR: Dgit wasn't called for the go get test"; ex
 rm -f $DGIT_TRACE
 
 echo "Go get a package with semver"
-go get "github.com/golang/text" || (echo "Go get failed"; exit 1)
+go get "golang.org/x/text" || (echo "Go get failed"; exit 1)
 test -d $GOPATH/pkg/mod/github.com/golang || (echo "ERROR: Go get didn't work"; exit 1)
 
 test -f $DGIT_TRACE


### PR DESCRIPTION
Attempting to `go get github.com/golang/text` instead of the
golang.org module name was causing go to fail. Use the
vanity path instead.