### PR TITLE
Add ability to index tags to git-indexpack

### DIFF
--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -596,7 +596,7 @@ func IndexPack(c *Client, opts IndexPackOptions, r io.Reader) (idx PackfileIndex
 		// or not.
 		var sha1 Sha1
 		switch t {
-		case OBJ_COMMIT, OBJ_TREE, OBJ_BLOB:
+		case OBJ_COMMIT, OBJ_TREE, OBJ_BLOB, OBJ_TAG:
 			sha1, _, err = HashSlice(t.String(), rawdata)
 			if err != nil && opts.Strict {
 				return indexfile, err
@@ -709,7 +709,6 @@ func IndexPack(c *Client, opts IndexPackOptions, r io.Reader) (idx PackfileIndex
 			wg.Done()
 		default:
 			panic("Unhandled type in IndexPack: " + t.String())
-
 		}
 	}
 	// Read the packfile trailer into the index trailer.

--- a/git/packfile.go
+++ b/git/packfile.go
@@ -80,7 +80,6 @@ func (p PackfileHeader) ReadHeaderSize(r io.Reader) (PackEntryType, PackEntrySiz
 			case OBJ_TREE:
 			case OBJ_BLOB:
 			case OBJ_TAG:
-				fmt.Printf("Tag!\n")
 			case OBJ_OFS_DELTA:
 			case OBJ_REF_DELTA:
 			}

--- a/go-get-modules-tests.sh
+++ b/go-get-modules-tests.sh
@@ -21,6 +21,9 @@ mkdir /tmp/gopath.$$
 export GOPATH=/tmp/gopath.$$
 export GO111MODULE=on # Force Go 1.11 to use the go modules
 
+# Force Go master (>=1.14) to use git instead of a proxy.
+export GOPROXY="direct"
+
 mkdir -p /tmp/foo.$$
 cd /tmp/foo.$$
 go mod init somesite.com/foo || exit 0

--- a/go-get-modules-tests.sh
+++ b/go-get-modules-tests.sh
@@ -34,7 +34,8 @@ rm -f $DGIT_TRACE
 
 echo "Go get a package with semver"
 go get "golang.org/x/text" || (echo "Go get failed"; exit 1)
-test -d $GOPATH/pkg/mod/github.com/golang || (echo "ERROR: Go get didn't work"; exit 1)
+# Only test the parent directory, because the exact package directory includes @version
+test -d $GOPATH/pkg/mod/golang.org/x || (echo "ERROR: Go get didn't work"; exit 1)
 
 test -f $DGIT_TRACE
 rm -f $DGIT_TRACE


### PR DESCRIPTION
This does just enough work to ensure that the go-get-modules-tests.sh passes.
No attempt has been done to ensure that it can read the tags after they've
been indexed or that deltas work against it.