### PR TITLE
Fix return code when git pull is already up to date.

### DIFF
--- a/git/merge.go
+++ b/git/merge.go
@@ -20,6 +20,8 @@ const (
 	MergeOctopus   = MergeStrategy("octopus")
 )
 
+var AlreadyUpToDate = fmt.Errorf("Already up-to-date.")
+
 // Merge options represent the options that may be passed on
 // the command line to "git merge"
 type MergeOptions struct {
@@ -89,7 +91,7 @@ func Merge(c *Client, opts MergeOptions, others []Commitish) error {
 		}
 	}
 	if !needsMerge {
-		return fmt.Errorf("Already up-to-date.")
+		return AlreadyUpToDate
 
 	}
 

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func main() {
 		subcommandUsage = "[<repository [<refspec>...]]"
 		if err := cmd.Pull(c, args); err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
-			if err.Error() == "Already up to date." {
+			if err.Error() == "Already up to date." || err == git.AlreadyUpToDate {
 				os.Exit(0)
 			}
 			os.Exit(2)


### PR DESCRIPTION
When the branch is already up to date, the program exit
code should be success (regardless of if the "Already up to date"
error came from git.Fetch or git.Merge)