### PR TITLE
Fix panic when trying to look into packs missing objects

### DIFF
--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -439,7 +439,7 @@ func (idx PackfileIndexV2) HasObject(s Sha1) bool {
 	// Packfiles are designed so that we could do a binary search here, but
 	// we don't need that optimization yet, so just do a linear search through
 	// the objects with the same first byte.
-	for i := startIdx - 1; idx.Sha1Table[i][0] == s[0] && i >= 0; i-- {
+	for i := int(startIdx - 1); i >= 0 && idx.Sha1Table[i][0] == s[0]; i-- {
 		if s == idx.Sha1Table[i] {
 			return true
 		}


### PR DESCRIPTION
When an object doesn't exist in a packfile, checking for
an object that starts with 0 can cause a panic, because
the i >= 0 check is after the access in the loop condition.

Switch the order to that the loop terminates before
accessing the index.