### PR TITLE
Improve index pack (and hence, clone) performance

### DIFF
--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -1,16 +1,16 @@
 package git
 
 import (
-	"fmt"
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 	"sort"
-	"sync"
 	"strings"
+	"sync"
+	"time"
 
 	"crypto/sha1"
 	"encoding/binary"
@@ -487,7 +487,7 @@ func (p *PackfileIndexV2) calculateTrailer() error {
 	return nil
 }
 
-type byteCounter struct{
+type byteCounter struct {
 	io.Reader
 	n int64
 }
@@ -569,10 +569,10 @@ func IndexPack(c *Client, opts IndexPackOptions, r io.Reader) (idx PackfileIndex
 
 	packhash, _ := indexfile.GetTrailer()
 	basename := fmt.Sprintf("%s/pack-%s", c.GitDir.File("objects/pack").String(), packhash)
-	if err := os.Rename(pack.Name(), basename + ".pack"); err != nil {
+	if err := os.Rename(pack.Name(), basename+".pack"); err != nil {
 		return indexfile, err
 	}
-	if err := os.Rename(pack.Name() + ".idx", basename + ".idx"); err != nil {
+	if err := os.Rename(pack.Name()+".idx", basename+".idx"); err != nil {
 		return indexfile, err
 	}
 	return indexfile, nil
@@ -791,9 +791,9 @@ func formatBytes(n int64) string {
 	if n <= 1024 {
 		return fmt.Sprintf("%v B", n)
 	} else if n <= 1024*1024 {
-		return fmt.Sprintf("%.2f KiB", float64(n) / float64(1024))
+		return fmt.Sprintf("%.2f KiB", float64(n)/float64(1024))
 	} else if n <= 1024*1024*1024 {
-		return fmt.Sprintf("%.2f MiB", float64(n) / float64(1024*1024))
+		return fmt.Sprintf("%.2f MiB", float64(n)/float64(1024*1024))
 	}
-	return fmt.Sprintf("%.2f GiB", float64(n) / float64(1024*1024*1024))
+	return fmt.Sprintf("%.2f GiB", float64(n)/float64(1024*1024*1024))
 }

--- a/git/packfile.go
+++ b/git/packfile.go
@@ -1,8 +1,8 @@
 package git
 
 import (
-	"bytes"
 	"bufio"
+	"bytes"
 	"compress/flate"
 	"fmt"
 	"io"

--- a/git/unpackobjects.go
+++ b/git/unpackobjects.go
@@ -62,7 +62,7 @@ func UnpackObjects(c *Client, opts UnpackObjectsOptions, r io.ReadSeeker) ([]Sha
 			return objects, err
 		}
 		t, s, ref, offset, _ := p.ReadHeaderSize(r)
-		rawdata := p.readEntryDataStream1(r)
+		rawdata := p.readEntryDataStream2(r)
 		switch t {
 		case OBJ_COMMIT, OBJ_TREE, OBJ_BLOB:
 			sha1, err := writeResolvedObject(c, t, rawdata)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/driusan/dgit
 
+go 1.14
+
 require (
 	9fans.net/go v0.0.0-20180727211846-5d4fa602e1e8 // indirect
 	bitbucket.org/mischief/libauth v0.0.0-20180917063427-eea7aee20a38

--- a/zlib/reader.go
+++ b/zlib/reader.go
@@ -48,8 +48,8 @@ type ZLibReader struct {
 	Digest       hash.Hash32
 	err          error
 	scratch      [4]byte
-
 }
+
 func (z *ZLibReader) CompressedSize() int64 {
 	return z.r.read
 }
@@ -73,9 +73,9 @@ func NewReader(r flate.Reader) (*ZLibReader, error) {
 	return NewReaderDict(r, nil)
 }
 
-type readCounter struct{
-	r io.Reader
-	rb io.ByteReader
+type readCounter struct {
+	r    io.Reader
+	rb   io.ByteReader
 	read int64
 }
 


### PR DESCRIPTION
This fixes some hacks to significantly improve the performance of index-pack (cloning the dgit repo on 9front went from ~160s to ~20s). Since we've forked the `compress/zlib` repository anyways, the signature is changed to always require a `flate.Reader` instead of an `io.Reader`. This means that reading a zlib stream doesn't overshoot the reader, but only works on things that have a `ReadByte` method. Since files don't implement `ReadByte`, `zlib` also grew the ability to tell you how many compressed bytes it read, meaning files can be wrapped in a `bufio` and then `Seek`ed back to the proper place.

In the refactoring the ability to simultaneously index as the pack is read from the network was lost, but this can be re-added in the future, for now the performance gains of not reading 1 byte at a time or seeking back looking for the digest more than makes up the difference.