### PR TITLE
Reparallelize the retrieval and indexing of pack files

### DIFF
--- a/cmd/indexpack.go
+++ b/cmd/indexpack.go
@@ -35,7 +35,6 @@ func IndexPack(c *git.Client, args []string) (err error) {
 
 	// Determine where to read the pack file based on command line options.
 	var packfile io.ReadSeeker
-	var idx git.PackfileIndex
 
 	if options.Stdin {
 		packfile = os.Stdin
@@ -97,10 +96,8 @@ func IndexPack(c *git.Client, args []string) (err error) {
 		defer f.Close()
 		options.Output = f
 	}
-	idx, err = git.IndexPack(c, options, packfile)
-	if err != nil {
+	if _, err := git.IndexPack(c, options, packfile); err != nil {
 		return err
 	}
-
-	return idx.WriteIndex(options.Output)
+	return nil
 }

--- a/git/packiterator.go
+++ b/git/packiterator.go
@@ -1,0 +1,84 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"encoding/binary"
+)
+
+type byteCounter struct {
+	io.Reader
+	n int64
+}
+
+func (r *byteCounter) Read(buf []byte) (int, error) {
+	n, err := r.Reader.Read(buf)
+	r.n += int64(n)
+	return n, err
+}
+
+type packIterator func(r io.ReaderAt, i, n int, loc int64, t PackEntryType, osz PackEntrySize, deltaref Sha1, deltaoffset ObjectOffset, rawdata []byte) error
+
+func iteratePack(c *Client, r io.Reader, initcallback func(int), callback packIterator, trailerCB func(packtrailer Sha1) error) (*os.File, error) {
+	// if the reader is not a file, tee it into a temp file to resolve
+	// deltas from.
+	var pack *os.File
+
+	counter := &byteCounter{r, 0}
+	if f, ok := r.(*os.File); ok && f != os.Stdin {
+		pack = f
+		r = counter
+	} else {
+		var err error
+		pack, err = ioutil.TempFile(c.GitDir.File("objects/pack").String(), ".tmppackfile")
+		if err != nil {
+			return nil, err
+		}
+		// Do not defer pack.Close, it's the caller's responsibility to close it.
+
+		// Only tee into the pack file if it's not a file
+		r = io.TeeReader(counter, pack)
+	}
+
+	var p PackfileHeader
+	if err := binary.Read(r, binary.BigEndian, &p); err != nil {
+		return nil, err
+	}
+
+	if p.Signature != [4]byte{'P', 'A', 'C', 'K'} {
+		return nil, fmt.Errorf("Invalid packfile: %+v", p.Signature)
+	}
+	if p.Version != 2 {
+		return nil, fmt.Errorf("Unsupported packfile version: %d", p.Version)
+	}
+
+	loc := counter.n
+	br := bufio.NewReader(r)
+	initcallback(int(p.Size))
+	for i := uint32(0); i < p.Size; i += 1 {
+		t, sz, deltasha, deltaoff, rawheader := p.ReadHeaderSize(br)
+
+		datacounter := byteReader{br, 0}
+		raw := p.readEntryDataStream1(&datacounter)
+
+		if err := callback(pack, int(i), int(p.Size), loc, t, sz, deltasha, deltaoff, raw); err != nil {
+			return pack, err
+		}
+
+		loc += int64(len(rawheader)) + int64(datacounter.n)
+	}
+
+	// We need to read the packfile trailer so that it gets tee'd into
+	// the temp file, or it won't be there for index-pack.
+	var trailer PackfileIndexV2
+	if err := binary.Read(br, binary.BigEndian, &trailer.Packfile); err != nil {
+		return nil, err
+	}
+	trailerCB(trailer.Packfile)
+
+	return pack, nil
+}


### PR DESCRIPTION
The indexing of packs now happen as it's coming over the wire, rather
than being performed in 2 distinct phases.

This also puts in place an infrastructure to remove the boilerplate of iterating over a packfile for features such as unpack-objects or verify-pack.