### PR TITLE
Concurrent Delta Resolution

### DIFF
--- a/git/packfile.go
+++ b/git/packfile.go
@@ -128,31 +128,6 @@ func (p PackfileHeader) ReadHeaderSize(r io.Reader) (PackEntryType, PackEntrySiz
 	return entrytype, size, Sha1{}, 0, dataread
 }
 
-// This is a hack to ensure zlib only reads 1 byte at a time and
-// doesn't overshoot, since we have no way to rewind the reader.
-type byteReader struct {
-	r io.Reader
-	n int
-}
-
-func (b *byteReader) Read(buf []byte) (int, error) {
-	n, err := b.r.Read(buf)
-	b.n += n
-	return n, err
-}
-
-func (b *byteReader) ReadByte() (byte, error) {
-	buf := make([]byte, 1)
-	n, err := b.Read(buf)
-	if err != nil {
-		return 0, err
-	}
-	if n != 1 {
-		return 0, fmt.Errorf("Unexpected number of bytes read. Got %v", n)
-	}
-	return buf[0], nil
-}
-
 func (p PackfileHeader) readEntryDataStream1(r flate.Reader) []byte {
 	b := new(bytes.Buffer)
 	zr, err := zlib.NewReader(r)


### PR DESCRIPTION
This updates index-pack to resolve deltas in files concurrently.

It also fixes the CRC32 in the index generated, which is now byte-for-byte identical to that which comes from the official git client.