### PR TITLE
Fix all Travis go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,9 @@ go:
 
   - "1.11.x"
   - "1.12.x"
-  # Last 2 releases and master. These should be periodically
-  # updated. It's assumed that if it works with 1.10 and the
-  # latest it works with everything in between.
   - "1.13.x"
   - "1.14.x"
   - master
-
-jobs:
-    allow_failures:
-        # Require git cat-file --batch to be implemented
-        - go: "1.13.x"
-        - go: "1.14.x"
-        - go: master
 
 go_import_path: github.com/driusan/dgit
 

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -57,14 +57,19 @@ func CatFile(c *git.Client, args []string) error {
 
 	oargs := flags.Args()
 
-	if options.Batch || options.BatchCheck {
-		return git.CatFileBatch(c, options, os.Stdin, os.Stdout)
-	}
 	switch len(oargs) {
 	case 0:
+		if options.Batch || options.BatchCheck {
+			return git.CatFileBatch(c, options, io.TeeReader(os.Stdin, os.Stderr), os.Stdout)
+		}
+
 		flags.Usage()
 		return nil
 	case 1:
+		if options.Batch || options.BatchCheck {
+			return git.CatFileBatch(c, options, os.Stdin, os.Stdout)
+		}
+
 		shas, err := git.RevParse(c, git.RevParseOptions{}, oargs)
 		if err != nil {
 			return err
@@ -80,6 +85,9 @@ func CatFile(c *git.Client, args []string) error {
 		}
 		return nil
 	case 2:
+		if options.Batch || options.BatchCheck {
+			return fmt.Errorf("May not combine batch with type")
+		}
 		shas, err := git.RevParse(c, git.RevParseOptions{}, []string{oargs[1]})
 		if err != nil {
 			return err

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -66,7 +65,7 @@ func CatFile(c *git.Client, args []string) error {
 	switch len(oargs) {
 	case 0:
 		if options.Batch || options.BatchCheck {
-			return git.CatFileBatch(c, options, io.TeeReader(os.Stdin, os.Stderr), os.Stdout)
+			return git.CatFileBatch(c, options, os.Stdin, os.Stdout)
 		}
 
 		flags.Usage()

--- a/cmd/catfile.go
+++ b/cmd/catfile.go
@@ -73,7 +73,11 @@ func CatFile(c *git.Client, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(val)
+		if options.Size || options.Type {
+			fmt.Println(val)
+		} else {
+			fmt.Print(val)
+		}
 		return nil
 	case 2:
 		shas, err := git.RevParse(c, git.RevParseOptions{}, []string{oargs[1]})

--- a/cmd/committree.go
+++ b/cmd/committree.go
@@ -48,7 +48,10 @@ func CommitTree(c *git.Client, args []string) (git.CommitID, error) {
 
 	flags.Parse(args)
 
-	finalMessage := strings.Join(m, "\n\n") + "\n"
+	finalMessage := strings.Join(m, "\n\n")
+	if finalMessage != "" {
+		finalMessage += "\n"
+	}
 
 	if len(flags.Args()) != 1 {
 		flags.Usage()
@@ -84,13 +87,17 @@ func CommitTree(c *git.Client, args []string) (git.CommitID, error) {
 
 	}
 
-	if (finalMessage == "\n" && messageFile == "") || messageFile == "-" {
+	if (finalMessage == "" && messageFile == "") || messageFile == "-" {
 		// No -m or -F provided, read from STDIN
 		m, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			return git.CommitID{}, err
 		}
-		finalMessage = "\n" + string(m)
+		if finalMessage == "" {
+			finalMessage = string(m)
+		} else {
+			finalMessage = "\n" + string(m)
+		}
 	} else if messageFile != "" {
 		// No -m, but -F was provided. Read from file passed.
 		m, err := ioutil.ReadFile(messageFile)
@@ -100,5 +107,5 @@ func CommitTree(c *git.Client, args []string) (git.CommitID, error) {
 		finalMessage = "\n" + string(m)
 	}
 
-	return git.CommitTree(c, git.CommitTreeOptions{}, tree, parents, strings.TrimSpace(finalMessage)+"\n")
+	return git.CommitTree(c, git.CommitTreeOptions{}, tree, parents, finalMessage)
 }

--- a/git/catfile.go
+++ b/git/catfile.go
@@ -81,6 +81,9 @@ func CatFileBatch(c *Client, opts CatFileOptions, r io.Reader, w io.Writer) erro
 		if len(obj) == 0 {
 			fmt.Fprintf(w, "%v missing\n", id)
 			continue
+		} else if len(obj) > 1 {
+			fmt.Fprintf(w, "%v ambiguous\n", id)
+			continue
 		}
 		gitobj, err := c.GetObject(obj[0].Id)
 		if err != nil {

--- a/git/catfile.go
+++ b/git/catfile.go
@@ -19,13 +19,11 @@ type CatFileOptions struct {
 
 func catFilePretty(c *Client, obj GitObject, opts CatFileOptions) (string, error) {
 	switch t := obj.GetType(); t {
-	case "commit", "tree", "blob":
+	case "commit", "tree", "blob", "tag":
 		if opts.Pretty {
 			return obj.String(), nil
 		}
 		return string(obj.GetContent()), nil
-	case "tag":
-		return "", fmt.Errorf("-p tag not yet implemented")
 	default:
 		return "", fmt.Errorf("Invalid git type: %s", t)
 	}
@@ -48,7 +46,7 @@ func CatFile(c *Client, typ string, s Sha1, opts CatFileOptions) (string, error)
 		return fmt.Sprintf("%v", obj.GetSize()), nil
 	default:
 		switch typ {
-		case "commit", "tree", "blob":
+		case "commit", "tree", "blob", "tag":
 			return string(obj.GetContent()), nil
 		default:
 			return "", fmt.Errorf("invalid object type %v", typ)

--- a/git/mktag.go
+++ b/git/mktag.go
@@ -63,6 +63,7 @@ func Mktag(c *Client, r io.Reader) (Sha1, error) {
 	switch typ {
 	case "commit":
 		// FIXME: This should actually verify the object
+	case "blob":
 	default:
 		return Sha1{}, fmt.Errorf(`error: char7: could not verify object.`)
 	}

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -11,7 +11,6 @@ export GOSUMDB="off"
 export ORIG_PATH=$PATH
 export ORIG_GIT=$(which git)
 
-mkdir -p $GOPATH
 echo "Adding dgit to the path"
 go build
 mkdir -p bin
@@ -25,8 +24,9 @@ export DGIT_TRACE=/tmp/go-get-dgit-log.$$.txt
 export GOPATH=/tmp/gopath.tst
 export TEST_PKG=github.com/blang/semver
 export TEST_GIT_DIR=${GOPATH}/src/${TEST_PKG}
-
+mkdir -p $GOPATH
 cd $GOPATH
+
 echo "Go get a package inside $GOPATH"
 go get -x ${TEST_PKG} || (echo "Go get ${TEST_PKG} failed"; exit 1)
 test -d ${GOPATH}/src/${TEST_PKG} || (echo "ERROR: Go get didn't work"; exit 1)

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -5,7 +5,6 @@ echo "Running go get tests"
 
 # Ensure that git is called, not the proxy
 export GOPROXY="direct"
-export GOSUMDB="off"
 
 # Keep existing state
 export ORIG_PATH=$PATH

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -11,10 +11,6 @@ export GOSUMDB="off"
 export ORIG_PATH=$PATH
 export ORIG_GIT=$(which git)
 
-export GOPATH=/tmp/gopath.tst
-export TEST_PKG=github.com/blang/semver
-export TEST_GIT_DIR=${GOPATH}/src/${TEST_PKG}
-
 mkdir -p $GOPATH
 echo "Adding dgit to the path"
 go build
@@ -23,6 +19,12 @@ cp dgit bin/git
 export PATH=$(pwd)/bin:$PATH
 
 export DGIT_TRACE=/tmp/go-get-dgit-log.$$.txt
+
+# Make a new $GOPATH and use it so that newer versions of
+# git with different default module modes don't get confused.
+export GOPATH=/tmp/gopath.tst
+export TEST_PKG=github.com/blang/semver
+export TEST_GIT_DIR=${GOPATH}/src/${TEST_PKG}
 
 cd $GOPATH
 echo "Go get a package inside $GOPATH"

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -11,9 +11,11 @@ export GOSUMDB="off"
 export ORIG_PATH=$PATH
 export ORIG_GIT=$(which git)
 
+export GOPATH=/tmp/gopath.tst
 export TEST_PKG=github.com/blang/semver
-export TEST_GIT_DIR=../../blang/semver
+export TEST_GIT_DIR=${GOPATH}/src/${TEST_PKG}
 
+mkdir -p $GOPATH
 echo "Adding dgit to the path"
 go build
 mkdir -p bin
@@ -22,9 +24,10 @@ export PATH=$(pwd)/bin:$PATH
 
 export DGIT_TRACE=/tmp/go-get-dgit-log.$$.txt
 
-echo "Go get a package"
-go get -x ${TEST_PKG} || (echo "Go get failed"; exit 1)
-test -d ${TEST_GIT_DIR} || (echo "ERROR: Go get didn't work"; exit 1)
+cd $GOPATH
+echo "Go get a package inside $GOPATH"
+go get -x ${TEST_PKG} || (echo "Go get ${TEST_PKG} failed"; exit 1)
+test -d ${GOPATH}/src/${TEST_PKG} || (echo "ERROR: Go get didn't work"; exit 1)
 
 test -f $DGIT_TRACE || (echo "ERROR: Dgit wasn't called for the go get test"; exit 1)
 rm -f $DGIT_TRACE
@@ -48,4 +51,5 @@ then
         exit 1
 fi
 
+rm -rf /tmp/gopath.tst
 export PATH=$ORIG_PATH

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -5,6 +5,7 @@ echo "Running go get tests"
 
 # Ensure that git is called, not the proxy
 export GOPROXY="direct"
+export GOSUMDB="off"
 
 # Keep existing state
 export ORIG_PATH=$PATH

--- a/go-get-tests.sh
+++ b/go-get-tests.sh
@@ -51,5 +51,4 @@ then
         exit 1
 fi
 
-rm -rf /tmp/gopath.tst
 export PATH=$ORIG_PATH

--- a/official-git/run-tests.sh
+++ b/official-git/run-tests.sh
@@ -41,13 +41,15 @@ sed s/init/remote/g git-remote > git-remote
 chmod a+x git-remote
 cd t
 
+# t0006 needs git repack and cat-file %(deltabase), cat-file options allow-unknown-type and cat-file --follow-symlinks
 # t0008 tests that are skipped require ! to negate a pattern. (GitHub issue #72)
 # t1004.16 needs "git merge-resolve" (which isn't documented anywhere I can find)
 # t1004.17 needs "git merge-recursive" (which also isn't documented)
 # t1014.26 needs "git config --unset-all"
 # t3000.7 requires git pack-refs
 
-GIT_SKIP_TESTS="t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2]"
+GIT_SKIP_TESTS="t1006.8[6789] t1006.9[0-9] t1006.10[0-9] t1006.110"
+GIT_SKIP_TESTS="$GIT_SKIP_TESTS t0008.321 t0008.323 t0008.37[0-9] t0008.38[0-7] t0008.39[1-2]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1004.1[6-7]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1014.26"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1308.2[6-7]" # No support for line ending handling or GIT_CEILING_DIRECTORIES
@@ -87,6 +89,8 @@ echo t1004-read-tree-m-u-wf
 ./t1004-read-tree-m-u-wf.sh
 echo t1005-read-tree-reset
 ./t1005-read-tree-reset.sh
+echo t1006-cat-file.sh
+./t1006-cat-file.sh
 echo t1008-read-tree-overlay
 ./t1008-read-tree-overlay.sh
 echo t1009-read-tree-new-index


### PR DESCRIPTION
This fixes all the versions of Go tested by Travis with dgit.

- `cat-file --batch` is implemented 
- cat-file tests from the official test client are added (up until the point that they deal with packs because while we read packs, we don't write them.)
- a bug where `:path` in rev-parse is supposed to refer to the index, not HEAD is fixed
- a new temporary $GOPATH is used by the go get tests so that the tests aren't added to dgit's go.mod in module mode.