### PR TITLE
Remove parallel indexing of packfiles

### DIFF
--- a/git/packiterator.go
+++ b/git/packiterator.go
@@ -91,7 +91,7 @@ func iteratePack(c *Client, r io.Reader, initcallback func(int), callback packIt
 		// Doing this in goroutines seems to crash 9front and provides very
 		// little performance gain, so for now only do 1 a time.
 		func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
-		//go func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
+			//go func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
 			defer wg.Done()
 			if err := callback(pack, i, psize, loc, compsize, t, sz, deltasha, deltaoff, raw); err != nil {
 				panic(err)

--- a/git/packiterator.go
+++ b/git/packiterator.go
@@ -88,7 +88,10 @@ func iteratePack(c *Client, r io.Reader, initcallback func(int), callback packIt
 
 		compsize := int64(len(rawheader)) + int64(datacounter.n)
 
-		go func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
+		// Doing this in goroutines seems to crash 9front and provides very
+		// little performance gain, so for now only do 1 a time.
+		func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
+		//go func(i int, psize int, loc int64, compsize int64, t PackEntryType, sz PackEntrySize, deltasha Sha1, deltaoff ObjectOffset, raw []byte) {
 			defer wg.Done()
 			if err := callback(pack, i, psize, loc, compsize, t, sz, deltasha, deltaoff, raw); err != nil {
 				panic(err)


### PR DESCRIPTION
This is causing "no procs" errors on 9front, but isn't giving
much performance gains, so for now call the callback on each
index in sequence.