### PR TITLE
Update handling of trees to handle trees generated by git9

### DIFF
--- a/git/entrymode.go
+++ b/git/entrymode.go
@@ -16,6 +16,10 @@ const (
 	ModeTree    = EntryMode(0040000)
 )
 
+// we sometimes see these coming from git9, although they chouldn't be valid
+// according to the git spec. We need to handle them to clone some repos anyways
+const modeGit9Tree = EntryMode(0040755)
+
 // TreeType prints the entry mode as the type that shows up in the "git ls-tree"
 // command.
 func (e EntryMode) TreeType() string {
@@ -25,7 +29,7 @@ func (e EntryMode) TreeType() string {
 		return "blob"
 	case ModeCommit:
 		return "commit"
-	case ModeTree:
+	case ModeTree, modeGit9Tree:
 		return "tree"
 	default:
 		panic(fmt.Sprintf("Invalid mode %o", e))
@@ -42,6 +46,8 @@ func ModeFromString(s string) (EntryMode, error) {
 		return ModeSymlink, nil
 	case "160000":
 		return ModeCommit, nil
+	case "040755":
+		return modeGit9Tree, fmt.Errorf("Bad tree type %v", s)
 	case "040000":
 		return ModeTree, nil
 	default:

--- a/git/expandtree.go
+++ b/git/expandtree.go
@@ -53,8 +53,8 @@ func expandGitTreeIntoIndexesRecursive(c *Client, t TreeID, prefix string, recur
 		} else {
 			dirname = IndexPath(prefix) + "/" + path
 		}
-		if (treeEntry.FileMode != ModeTree) || showTreeEntry || !recurse {
 
+		if (treeEntry.FileMode.TreeType() != "tree") || showTreeEntry || !recurse {
 			newEntry := IndexEntry{}
 			newEntry.Sha1 = treeEntry.Sha1
 			newEntry.Mode = treeEntry.FileMode
@@ -84,7 +84,7 @@ func expandGitTreeIntoIndexesRecursive(c *Client, t TreeID, prefix string, recur
 			}
 			newEntries = append(newEntries, &newEntry)
 		}
-		if treeEntry.FileMode == ModeTree && recurse {
+		if treeEntry.FileMode.TreeType() == "tree" && recurse {
 			subindexes, err := expandGitTreeIntoIndexesRecursive(c, TreeID(treeEntry.Sha1), dirname.String(), recurse, showTreeEntry, treeOnly)
 			if err != nil {
 				return nil, err

--- a/git/objects.go
+++ b/git/objects.go
@@ -179,11 +179,12 @@ func (t GitTreeObject) String() string {
 			perm := split[0]
 			name := split[1]
 			var gtype string
-			if string(perm) == "40000" {
+			if string(perm) == "40000" || string(perm) == "40755" {
 				// the only possible perms in a tree are 40000 (tree), 100644 (blob),
 				// and 100755 (blob with mode +x, also a blob).. so we just check for
 				// the only possible perm value for a tree, instead of looking up
 				// the object in the .git/objects database.
+				// git9 sometimes generates trees of 40755, so we fix them up here too.
 				//
 				// It's also supposed to be printed 0-padded with git cat-file -p,
 				// so we just change the string since we're here.

--- a/git/sha1.go
+++ b/git/sha1.go
@@ -649,7 +649,9 @@ func parseRawTreeLine(entryStart int, treecontent []byte) (IndexPath, TreeEntry,
 
 			var mode EntryMode
 			switch string(perm) {
-			case "40000":
+			case "40755": // sometimes in git9 repositories
+				mode = modeGit9Tree
+			case "40000": // valid git tree
 				mode = ModeTree
 			case "100644":
 				mode = ModeBlob


### PR DESCRIPTION
git9 incorrectly uses 040755 instead of 040000 for the mode
of subdirectories in trees. Since even if it's fixed upsteam
the trees will still be out in the wild, this updates dgit to
be a little more lenient of what it considers a tree.