### PR TITLE
Add support for t5300 pack-objects test

### DIFF
--- a/cmd/packobjects.go
+++ b/cmd/packobjects.go
@@ -6,12 +6,14 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/driusan/dgit/git"
 )
 
-func PackObjects(c *git.Client, input io.Reader, args []string) {
+func PackObjects(c *git.Client, input io.Reader, args []string) (rv error) {
 	flags := flag.NewFlagSet("pack-objects", flag.ExitOnError)
 	flags.SetOutput(flag.CommandLine.Output())
 	flags.Usage = func() {
@@ -20,13 +22,17 @@ func PackObjects(c *git.Client, input io.Reader, args []string) {
 		flags.PrintDefaults()
 	}
 
+	var opts git.PackObjectsOptions
 	// These flags can be moved out of these lists and below as proper flags as they are implemented
-	for _, bf := range []string{"q", "progress", "all-progress", "all-project-implied", "no-reuse-delta", "delta-base-offset", "non-empty", "local", "incremental", "revs", "unpacked", "all", "stdout", "shallow", "keep-true-parents"} {
+	for _, bf := range []string{"q", "progress", "all-progress", "all-project-implied", "no-reuse-delta", "non-empty", "local", "incremental", "revs", "unpacked", "all", "stdout", "shallow", "keep-true-parents"} {
 		flags.Var(newNotimplBoolValue(), bf, "Not implemented")
 	}
-	for _, sf := range []string{"window", "depth", "keep-pack"} {
+	for _, sf := range []string{"depth", "keep-pack"} {
 		flags.Var(newNotimplStringValue(), sf, "Not implemented")
 	}
+
+	flags.IntVar(&opts.Window, "window", 0, "Size of the sliding window to use for delta calculation")
+	flags.BoolVar(&opts.DeltaBaseOffset, "delta-base-offset", false, "Use offset deltas instead of ref deltas in pack")
 
 	flags.Parse(args)
 
@@ -35,8 +41,37 @@ func PackObjects(c *git.Client, input io.Reader, args []string) {
 		os.Exit(2)
 	}
 
-	f, _ := os.Create(flags.Arg(0) + ".pack")
-	defer f.Close()
+	var trailer git.Sha1
+	dir := filepath.Dir(flags.Arg(0))
+	f, err := ioutil.TempFile(dir, "dgitpack")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rv != nil {
+			f.Close()
+			os.Remove(f.Name())
+		} else {
+			if err := os.Rename(f.Name(), fmt.Sprintf("%s-%s.pack", flags.Arg(0), trailer)); err != nil {
+				rv = err
+				return
+			}
+			idx, err := os.Create(fmt.Sprintf("%s-%s.idx", flags.Arg(0), trailer))
+			if err != nil {
+				rv = err
+				return
+			}
+			var iopts git.IndexPackOptions
+			iopts.Output = idx
+			f.Seek(0, io.SeekStart)
+			if _, err := git.IndexPack(c, iopts, f); err != nil {
+				rv = err
+			}
+			f.Close()
+			idx.Close()
+			return
+		}
+	}()
 
 	var objects []git.Sha1
 	scanner := bufio.NewScanner(input)
@@ -51,5 +86,7 @@ func PackObjects(c *git.Client, input io.Reader, args []string) {
 		}
 		objects = append(objects, s)
 	}
-	git.SendPackfile(c, f, objects)
+	trailer, rv = git.PackObjects(c, opts, f, objects)
+	fmt.Printf("%s", trailer)
+	return
 }

--- a/git/clone.go
+++ b/git/clone.go
@@ -101,9 +101,11 @@ func Clone(opts CloneOptions, rmt Remote, dst File) error {
 		}
 		refname := strings.Replace(ref.Name, "refs/heads/", "refs/remotes/"+org+"/", 1)
 		f := c.GitDir.File(File(refname))
-		if err := f.Create(); err != nil {
+		cf, err := f.Create()
+		if err != nil {
 			return err
 		}
+		cf.Close()
 		if err := f.Append(fmt.Sprintf("%v\n", ref.Value)); err != nil {
 			return err
 		}

--- a/git/file.go
+++ b/git/file.go
@@ -123,17 +123,15 @@ func (f File) IsSymlink() bool {
 	return stat.Mode()&os.ModeSymlink == os.ModeSymlink
 }
 
-func (f File) Create() error {
+func (f File) Create() (*os.File, error) {
 	dir := File(filepath.Dir(f.String()))
 	if !dir.Exists() {
 		if err := os.MkdirAll(dir.String(), 0755); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	fi, err := os.Create(f.String())
-	fi.Close()
-	return err
+	return os.Create(f.String())
 }
 
 // Reads the entire contents of file and return as a string. Note

--- a/git/objects.go
+++ b/git/objects.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -281,7 +282,10 @@ func (c *Client) getObject(sha1 Sha1, metaOnly bool) (GitObject, error) {
 		c.objcache[shaRef{sha1, metaOnly}] = gobj
 		return gobj, nil
 	} else {
-		objectname := fmt.Sprintf("%s/objects/%x/%x", c.GitDir, sha1[0:1], sha1[1:])
+		objectname := filepath.Join(c.ObjectDir,
+			fmt.Sprintf("%02x", sha1[0:1]),
+			fmt.Sprintf("%18x", sha1[1:]),
+		)
 		f, err := os.Open(objectname)
 		if err != nil {
 			return nil, err

--- a/git/packobjects.go
+++ b/git/packobjects.go
@@ -1,14 +1,28 @@
 package git
 
 import (
+	"fmt"
+	"io"
+
 	"crypto/sha1"
 	"encoding/binary"
-	"io"
 )
+
+type PackObjectsOptions struct {
+	// The number of entries to use for the sliding window for delta
+	// calculations
+	Window int
+
+	// Use offset deltas instead of refdeltas when calculating delta
+	DeltaBaseOffset bool
+}
 
 // Writes a packfile to w of the objects objects from the client's
 // GitDir.
-func SendPackfile(c *Client, w io.Writer, objects []Sha1) error {
+func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1) (trailer Sha1, err error) {
+	if opts.Window != 0 {
+		return Sha1{}, fmt.Errorf("Deltas not supported")
+	}
 	sha := sha1.New()
 	w = io.MultiWriter(w, sha)
 	n, err := w.Write([]byte{'P', 'A', 'C', 'K'})
@@ -16,7 +30,7 @@ func SendPackfile(c *Client, w io.Writer, objects []Sha1) error {
 		panic("Could not write signature")
 	}
 	if err != nil {
-		return err
+		return Sha1{}, err
 	}
 
 	// Version
@@ -28,15 +42,15 @@ func SendPackfile(c *Client, w io.Writer, objects []Sha1) error {
 
 		err := s.WriteVariable(w, obj.PackEntryType(c))
 		if err != nil {
-			return err
+			return Sha1{}, err
 		}
 
 		err = obj.CompressedWriter(c, w)
 		if err != nil {
-			return err
+			return Sha1{}, err
 		}
 	}
-	trailer := sha.Sum(nil)
-	w.Write(trailer)
-	return nil
+	trail := sha.Sum(nil)
+	w.Write(trail)
+	return Sha1FromSlice(trail)
 }

--- a/git/unpackobjects.go
+++ b/git/unpackobjects.go
@@ -43,6 +43,10 @@ func UnpackObjects(c *Client, opts UnpackObjectsOptions, r io.Reader) ([]Sha1, e
 	priorObjects := make(map[Sha1]*packObject)
 	// For OFS_DELTA to resolve.
 	priorLocations := make(map[ObjectOffset]*packObject)
+
+	if f := File(c.ObjectDir); !f.Exists() {
+		os.MkdirAll(f.String(), 0755)
+	}
 	cb := func(r io.ReaderAt, i, n int, location int64, t PackEntryType, sz PackEntrySize, refSha1 Sha1, offset ObjectOffset, rawdata []byte) error {
 		if !opts.Quiet {
 			progressF("Unpacking objects: %2.f%% (%d/%d)", i+1 == n, (float32(i+1)/float32(n))*100, i+1, n)

--- a/git/updateref.go
+++ b/git/updateref.go
@@ -24,9 +24,11 @@ func updateReflog(c *Client, create bool, file File, oldvalue, newvalue Commitis
 		if !create {
 			return nil
 		}
-		if err := file.Create(); err != nil {
+		f, err := file.Create()
+		if err != nil {
 			return err
 		}
+		f.Close()
 	}
 
 	now := time.Now()

--- a/main.go
+++ b/main.go
@@ -319,7 +319,10 @@ func main() {
 		}
 	case "pack-objects":
 		subcommandUsage = "<basename>"
-		cmd.PackObjects(c, os.Stdin, args)
+		if err := cmd.PackObjects(c, os.Stdin, args); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(4)
+		}
 	case "send-pack":
 		cmd.SendPack(c, args)
 	case "read-tree":

--- a/official-git/run-tests.sh
+++ b/official-git/run-tests.sh
@@ -57,6 +57,8 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1450.49 t1450.5[0-9]" # Only up to nul in commi
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1503.[5-7] t1503.10" # No support for @{suffix} (looking up based on reflog) in rev-parse
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t2018.[6-7] t2018.[9] t2018.1[5-8]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t3000.7"
+# Only the setup for pack-objects tests has been tested
+GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5300.1[2-9] t5300.2[0-9] t5300.3[0-3]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5512.1[1234] t5512.1[079] t5512.9 t5512.2[01234]" # 1[234] seem to get stuck in an infinite loop. The rest fail and need investigation.
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5510.[4-9] t5510.[1-7][0-9]" # Just the basic fetch tests are working for now
 export GIT_SKIP_TESTS
@@ -148,6 +150,8 @@ echo t4113-apply-ending
 ./t4113-apply-ending.sh
 echo t4123-apply-shrink
 ./t4123-apply-shrink.sh
+echo t5300-pack-object.sh
+./t5300-pack-object.sh
 echo t5510-fetch.sh
 ./t5510-fetch.sh
 echo t5512-ls-remote.sh


### PR DESCRIPTION
This adds support for the first few tests of t5300, which
tests pack/unpack objects in the official git client. It passes
until the point where it compares the delta flavours.

This mostly involves slightly better support for the
`GIT_OBJECT_DIRECTORY` environment variable, naming the packs correctly
(with the trailer as a suffix) and parsing some command line options. 