### PR TITLE
Create new delta package

### DIFF
--- a/git/delta/calculator.go
+++ b/git/delta/calculator.go
@@ -1,0 +1,302 @@
+package delta
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"index/suffixarray"
+	"io"
+)
+
+// The minimum number of characters to copy from the stream. If
+// there is not a prefix amount to copy from the stream.
+const minCopy = 3
+
+// We use a simple interface to make our calculate function easily
+// testable and debuggable.
+type instruction interface {
+	// Write the instruction to w
+	write(w io.Writer) error
+
+	// Used by the test suite
+	equals(i2 instruction) bool
+}
+
+// insert instruction. Insert the bytes into the stream.
+type insert []byte
+
+func (i insert) write(w io.Writer) error {
+	remaining := []byte(i)
+	for len(remaining) > 0 {
+		if len(remaining) < 128 {
+			// What's left fits in a single insert
+			// instruction
+			if _, err := w.Write([]byte{byte(len(remaining))}); err != nil {
+				return err
+			}
+			if _, err := w.Write(remaining); err != nil {
+				return err
+			}
+			remaining = nil
+		} else {
+			// What's left doesn't fit in a single
+			// insert instruction, so insert the largest
+			// amount that does
+			if _, err := w.Write([]byte{127}); err != nil {
+				return err
+			}
+			if _, err := w.Write(remaining[:127]); err != nil {
+				return err
+			}
+			remaining = remaining[127:]
+		}
+	}
+	return nil
+}
+
+func (i insert) equals(i2 instruction) bool {
+	i2i, ok := i2.(insert)
+	if !ok {
+		return false
+	}
+	return string(i) == string(i2i)
+}
+
+type copyinst struct {
+	offset, length uint32
+}
+
+func (c copyinst) equals(i2 instruction) bool {
+	i2c, ok := i2.(copyinst)
+	if !ok {
+		return false
+	}
+	return i2c.offset == c.offset && i2c.length == c.length
+}
+
+// The meat of our algorithm. Calculate a list of instructions to
+// insert into the stream.
+func calculate(src, dst []byte) *list.List {
+	instructions := list.New()
+	index := suffixarray.New(src)
+	remaining := dst
+	for len(remaining) > 0 {
+		nexto, nextl := longestPrefix(index, remaining)
+		if nextl > 0 {
+			instructions.PushBack(copyinst{uint32(nexto), uint32(nextl)})
+			remaining = remaining[nextl:]
+			continue
+		}
+		// FIXME: Find where the next prefix > minCopy starts,
+		// insert until then instead of always inserting minCopy
+		if len(remaining) <= minCopy {
+			instructions.PushBack(insert(remaining))
+			remaining = nil
+			continue
+		}
+
+		nextOffset := nextPrefixStart(index, dst)
+		if nextOffset >= 0 {
+			instructions.PushBack(insert(remaining[:nextOffset]))
+			remaining = remaining[nextOffset:]
+		} else {
+			// nextPrefixStart went through the whole string
+			// and didn't find anything, so insert the whole string
+			instructions.PushBack(insert(remaining))
+			remaining = nil
+		}
+
+	}
+	return instructions
+}
+
+// Returns the longest prefix of dst that is found somewhere in src.
+func longestPrefix(src *suffixarray.Index, dst []byte) (offset, length int) {
+	// First the simple edge simple cases. Is it smaller than minCopy? Does
+	// it have a prefix of at least minCopy?
+	if len(dst) < minCopy {
+		return 0, -1
+	}
+
+	// If there's no prefix at all of at least length minCopy,
+	// don't bother searching for one.
+	if result := src.Lookup(dst[:minCopy], 1); len(result) == 0 {
+		return 0, -1
+	}
+
+	// If the entire dst exists somewhere in src, return the first
+	// one found.
+	if result := src.Lookup(dst, 1); len(result) > 0 {
+		return result[0], len(dst)
+	}
+
+	// We know there's a substring somewhere but the whole thing
+	// isn't a substring, brute force the location of the longest
+	// substring with a binary search of our suffix array.
+	length = -1
+	minIdx := minCopy
+	maxIdx := len(dst)
+	for i := minIdx; maxIdx-minIdx > 1; i = ((maxIdx - minIdx) / 2) + minIdx {
+		if result := src.Lookup(dst[:i], 1); result != nil {
+			offset = result[0]
+			length = i
+			minIdx = i
+		} else {
+			maxIdx = i - 1
+		}
+	}
+	return
+}
+
+// Find the start of the next prefix of dst that has a size of at least
+// minCopy
+func nextPrefixStart(src *suffixarray.Index, dst []byte) (offset int) {
+	for i := 1; i < len(dst); i++ {
+		end := i + minCopy
+		if end > len(dst) {
+			end = len(dst)
+		}
+		if result := src.Lookup(dst[i:end], 1); result != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// Calculate how to generate dst using src as the base
+// of the deltas and write the result to w.
+func Calculate(w io.Writer, src, dst []byte) error {
+	instructions := calculate(src, dst)
+	var buf bytes.Buffer
+	// Write src and dst length header
+	if err := writeVarInt(&buf, len(src)); err != nil {
+		return err
+	}
+	if err := writeVarInt(&buf, len(dst)); err != nil {
+		return err
+	}
+	if n, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	} else if n != buf.Len() {
+		return fmt.Errorf("Could not write delta header")
+	}
+
+	// Write the instructions themselves
+	for e := instructions.Front(); e != nil; e = e.Next() {
+		inst := e.Value.(instruction)
+
+		if err := inst.write(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c copyinst) write(w io.Writer) error {
+	var buf bytes.Buffer
+	instbyte := byte(0x80)
+
+	// Set the offset bits in the instruction
+	if c.offset&0xff != 0 {
+		instbyte |= 0x01
+	}
+	if c.offset&0xff00 != 0 {
+		instbyte |= 0x02
+	}
+	if c.offset&0xff0000 != 0 {
+		instbyte |= 0x04
+	}
+	if c.offset&0xff000000 != 0 {
+		instbyte |= 0x08
+	}
+
+	// Set the length bits in the instruction
+	if c.length > 0xffffff {
+		// FIXME: Decompose this into multiple copy
+		// instructions
+	} else if c.length == 0x10000 {
+		// 0x10000 is a special case, encoded as 0
+	} else {
+		// Encode the bits in the byte that denote
+		// which bits are incoming in the stream
+		// for length
+		if c.length&0xff != 0 {
+			instbyte |= 0x10
+		}
+
+		if c.length&0xff00 != 0 {
+			instbyte |= 0x20
+		}
+
+		if c.length&0xff0000 != 0 {
+			instbyte |= 0x40
+		}
+	}
+	// Write the header
+	if err := buf.WriteByte(instbyte); err != nil {
+		return err
+	}
+
+	// Write the offset bytes
+	if val := byte(c.offset & 0xff); val != 0 {
+		if err := buf.WriteByte(val); err != nil {
+			return err
+		}
+	}
+	if val := byte(c.offset >> 8 & 0xff); val != 0 {
+		if err := buf.WriteByte(val); err != nil {
+			return err
+		}
+	}
+	if val := byte(c.offset >> 16 & 0xff); val != 0 {
+		if err := buf.WriteByte(val); err != nil {
+			return err
+		}
+	}
+	if val := byte(c.offset >> 24 & 0xff); val != 0 {
+		if err := buf.WriteByte(val); err != nil {
+			return err
+		}
+	}
+
+	// Write the length
+	if c.length != 0x10000 {
+		if val := byte(c.length & 0xff); val != 0 {
+			if err := buf.WriteByte(val); err != nil {
+				return err
+			}
+		}
+		if val := byte((c.length >> 8) & 0xff); val != 0 {
+			if err := buf.WriteByte(val); err != nil {
+				return err
+			}
+
+		}
+		if val := byte((c.length >> 16) & 0xff); val != 0 {
+			if err := buf.WriteByte(val); err != nil {
+				return err
+			}
+
+		}
+
+	}
+	if n, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	} else if n != buf.Len() {
+		return fmt.Errorf("Could not write entire instruction")
+	}
+	return nil
+}
+
+func writeVarInt(w io.ByteWriter, val int) error {
+	for val >= 128 {
+		if err := w.WriteByte(byte(val & 127)); err != nil {
+			return err
+		}
+		val = val >> 7
+	}
+	if err := w.WriteByte(byte(val & 127)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/git/delta/calculator_test.go
+++ b/git/delta/calculator_test.go
@@ -1,0 +1,267 @@
+package delta
+
+import (
+	"bytes"
+	"container/list"
+	"io/ioutil"
+	"testing"
+)
+
+func TestCalculator(t *testing.T) {
+	tests := []struct {
+		label    string
+		src, dst []byte
+		want     []instruction
+	}{
+		{
+			"No intersection",
+			[]byte("abc"),
+			[]byte("def"),
+			[]instruction{insert("def")},
+		},
+		{
+			"dst is prefix",
+			[]byte("defabc"),
+			[]byte("def"),
+			[]instruction{copyinst{0, 3}},
+		},
+		{
+			"dst is suffix",
+			[]byte("abcdef"),
+			[]byte("def"),
+			[]instruction{copyinst{3, 3}},
+		},
+		{
+			"src is substring of dst",
+			[]byte("def"), []byte("defabc"),
+			[]instruction{copyinst{0, 3}, insert("abc")},
+		},
+		{
+			// Mostly to make sure we don't crash if < minCopy
+			"small value",
+			[]byte("d"), []byte("d"),
+			[]instruction{insert("d")},
+		},
+		{
+			"src is embedded in dst",
+			[]byte("def"), []byte("abdefab"),
+			[]instruction{
+				insert("ab"),
+				copyinst{0, 3},
+				insert("ab"),
+			},
+		},
+		{
+			"random common substring",
+			[]byte("abDxxxAxF"), []byte("AxxxFwX"),
+			[]instruction{
+				insert("A"),
+				copyinst{3, 3},
+				insert("FwX"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		instructions := calculate(tc.src, tc.dst)
+		if identicalInstructions(tc.want, instructions) != true {
+			t.Errorf("%s", tc.label)
+		}
+	}
+}
+
+func identicalInstructions(want []instruction, got *list.List) bool {
+	if len(want) != got.Len() {
+		return false
+	}
+
+	i := 0
+	for e := got.Front(); e != nil; e = e.Next() {
+		i1 := want[i]
+		if !i1.equals(e.Value.(instruction)) {
+			return false
+		}
+		i++
+	}
+	return true
+}
+
+func TestCalculatorWriteInsert(t *testing.T) {
+	var buf bytes.Buffer
+
+	i := insert("abc")
+	i.write(&buf)
+
+	// simple insert instructions
+	var want []byte = []byte{3, 97, 98, 99}
+	if got := buf.String(); got != string(want) {
+		t.Errorf("Simple insert: got %s want %s", got, want)
+	}
+
+	buf.Reset()
+	// long insert, needs to generate 2 insert instructions
+	// in the stream.
+	// 13 sequences of 10 characters
+	i = insert("0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789" +
+		"0123456789")
+	i.write(&buf)
+	want = []byte{
+		// First 127 characters
+		127,
+		// 0-9, x12
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
+		// 0-6
+		48, 49, 50, 51, 52, 53, 54,
+		// Insert for the remaining characters
+		3,
+		55, 56, 57,
+	}
+	if got := buf.String(); got != string(want) {
+		t.Errorf("Long insert: got %s want %s", got, want)
+	}
+
+}
+
+func TestCalculatorWriteCopy(t *testing.T) {
+	tests := []struct {
+		label string
+		i     copyinst
+		want  []byte
+	}{
+		{
+			"Length size 1 copy",
+			copyinst{0, 1},
+			[]byte{0x80 | 0x10, 1},
+		},
+		{
+			"Length size 2 copy",
+			copyinst{0, 1 << 8},
+			[]byte{0x80 | 0x20, 1},
+		},
+		{
+			"Length size 3 copy",
+			// can't use 1 << 16 or we'd hit
+			// the special case
+			copyinst{0, 2 << 16},
+			[]byte{0x80 | 0x40, 2},
+		},
+		{
+			"Length size 1 and 2 copy",
+			copyinst{0, (2 << 8) | 1},
+			[]byte{0x80 | 0x10 | 0x20, 1, 2},
+		},
+		{
+			"Length size 1 and 3 copy",
+			copyinst{0, (3 << 16) | 1},
+			[]byte{0x80 | 0x10 | 0x40, 1, 3},
+		},
+		{
+			"Length size 2 and 3 copy",
+			copyinst{0, (3 << 16) | (2 << 8)},
+			[]byte{0x80 | 0x20 | 0x40, 2, 3},
+		},
+		{
+			"Length size 1, 2 and 3 copy",
+			copyinst{0, (3 << 16) | (2 << 8) | 1},
+			[]byte{0x80 | 0x10 | 0x20 | 0x40, 1, 2, 3},
+		},
+		{
+			"Length special case size copy",
+			copyinst{0, 0x10000},
+			[]byte{0x80},
+		},
+		{
+			"Offset size 1 encoding",
+			copyinst{1, 0x10000},
+			[]byte{0x80 | 0x01, 1},
+		},
+		{
+			"Offset size 2 encoding",
+			copyinst{1 << 8, 0x10000},
+			[]byte{0x80 | 0x02, 1},
+		},
+		{
+			"Offset size 3 encoding",
+			copyinst{1 << 16, 0x10000},
+			[]byte{0x80 | 0x04, 1},
+		},
+		{
+			"Offset size 4 encoding",
+			copyinst{1 << 24, 0x10000},
+			[]byte{0x80 | 0x08, 1},
+		},
+		{
+			"Multibyte offset size encoding (bits 1 and 4)",
+			copyinst{4<<24 | 1, 0x10000},
+			[]byte{0x80 | 0x01 | 0x08, 1, 4},
+		},
+		{
+			"Mixed offset and length encoding",
+			copyinst{1<<8 | 2, 3},
+			[]byte{
+				0x80 |
+					0x1 | 0x2 | // offset bits
+					0x10, // length bits
+				2, 1, // offset first
+				3, // length second
+			},
+		},
+	}
+	var buf bytes.Buffer
+
+	for _, tc := range tests {
+		buf.Reset()
+		tc.i.write(&buf)
+
+		if got := buf.String(); got != string(tc.want) {
+			t.Errorf("%s: got %v want %v", tc.label, []byte(got), tc.want)
+		}
+	}
+}
+
+// Calculate a delta and ensure reading it resolves to the same
+// value
+func TestSanityTest(t *testing.T) {
+	// A random 2 instruction from TestCalculator.
+	// src is "def", dst is "defabc". Should result
+	// in both a copy and an insert.
+	// (was tested in TestCalculator)
+	var delta bytes.Buffer
+	base := []byte("def")
+	target := []byte("defabc")
+	Calculate(&delta, base, target)
+
+	resolved := NewReader(
+		bytes.NewReader(delta.Bytes()),
+		bytes.NewReader(base),
+	)
+	val, err := ioutil.ReadAll(&resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(val) != string(target) {
+		t.Errorf("Unexpected delta resolution: got %v want %v", val, target)
+	}
+}

--- a/git/delta/doc.go
+++ b/git/delta/doc.go
@@ -1,0 +1,3 @@
+// Delta provides functions for reading and calculating git
+// styles deltas.
+package delta


### PR DESCRIPTION
Move delta Reader into new package and create delta writing infrastructure

This creates a new package "delta" which is concerned with reading and
writing git deltas. The old git.delta type is now a delta.Reader and
indexpack is updated accordingly.

The new "delta.Calculate" function takes 2 byte slices and calculates a
delta that goes from src to dst, writing the resulting delta to an
io.Writer.

PackObjects doesn't yet use it, but this puts the plumbing in place to
calculate ref and offset deltas.