### PR TITLE
Fix push

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"os"
-	"strings"
 	"io"
 	"io/ioutil"
+	"os"
+	"strings"
 
 	"github.com/driusan/dgit/git"
 )

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -3,9 +3,10 @@ package cmd
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
+	"io"
+	"io/ioutil"
 
 	"github.com/driusan/dgit/git"
 )
@@ -100,24 +101,20 @@ To push and set the upstream to the remote named "origin" use:
 			remoteCommits = append(remoteCommits, git.CommitID(refsha))
 		}
 	}
-	var objects strings.Builder
-	if _, err := git.RevList(c, git.RevListOptions{Objects: true}, &objects, []git.Commitish{localSha[0]}, remoteCommits); err != nil {
+	objs, err := git.RevList(c, git.RevListOptions{Objects: true, Quiet: true}, nil, []git.Commitish{localSha[0]}, remoteCommits)
+	if err != nil {
 		return err
 	}
 
-	f, err := ioutil.TempFile("", "sendpack")
-	if err != nil {
-		panic(err)
-	}
-	os.Remove(f.Name())
-	fmt.Fprintf(f, objects.String())
-
-	PackObjects(c, strings.NewReader(objects.String()), []string{f.Name()})
-	f, err = os.Open(f.Name() + ".pack")
+	f, err := ioutil.TempFile("", "dgitpush")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(f.Name())
+	if _, err := git.PackObjects(c, git.PackObjectsOptions{}, f, objs); err != nil {
+		return err
+	}
+	f.Seek(0, io.SeekStart)
 	stat, err := f.Stat()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix push which was broken while fixing pack-object tests. cmd.PackObject's behaviour had changed to fix the official git tests and push was incorrectly using that instead of git.PackObjects.