### PR TITLE
Add support for deltas in git pack-objects and fix tests

### DIFF
--- a/cmd/packobjects.go
+++ b/cmd/packobjects.go
@@ -31,7 +31,7 @@ func PackObjects(c *git.Client, input io.Reader, args []string) (rv error) {
 		flags.Var(newNotimplStringValue(), sf, "Not implemented")
 	}
 
-	flags.IntVar(&opts.Window, "window", 0, "Size of the sliding window to use for delta calculation")
+	flags.IntVar(&opts.Window, "window", 10, "Size of the sliding window to use for delta calculation")
 	flags.BoolVar(&opts.DeltaBaseOffset, "delta-base-offset", false, "Use offset deltas instead of ref deltas in pack")
 
 	flags.Parse(args)

--- a/git/client.go
+++ b/git/client.go
@@ -578,7 +578,7 @@ func (c *Client) HaveObject(id Sha1) (found bool, packedfile File, err error) {
 	}
 
 	// Then, check if it's in a pack file.
-	files, err := ioutil.ReadDir(c.GitDir.File("objects/pack").String())
+	files, err := ioutil.ReadDir(filepath.Join(c.ObjectDir, "pack"))
 	if err != nil {
 		// The pack directory doesn't exist. It's not an error, but it definitely
 		// doesn't have the file..
@@ -589,7 +589,7 @@ func (c *Client) HaveObject(id Sha1) (found bool, packedfile File, err error) {
 		if filepath.Ext(fi.Name()) == ".idx" {
 			// It's ambiguous if Name() has the full path or not according to what
 			// ReadDir returns, so just be very cautious on how we open it.
-			name := c.GitDir.File(File(fmt.Sprintf("objects/pack/%s", filepath.Base(fi.Name()))))
+			name := File(filepath.Join(c.ObjectDir, "pack", filepath.Base(fi.Name())))
 			f, err := os.Open(name.String())
 			if err != nil {
 				log.Print(err)

--- a/git/delta/calculator.go
+++ b/git/delta/calculator.go
@@ -303,16 +303,5 @@ func writeVarInt(w io.Writer, val int) error {
 	if _, err := w.Write(buf[:n]); err != nil {
 		return err
 	}
-	/*
-		for val >= 128 {
-			if err := w.WriteByte(byte(val & 127)); err != nil {
-				return err
-			}
-			val = val >> 7
-		}
-		if err := w.WriteByte(byte(val & 127)); err != nil {
-			return err
-		}
-	*/
 	return nil
 }

--- a/git/delta/calculator.go
+++ b/git/delta/calculator.go
@@ -96,7 +96,7 @@ func calculate(src, dst []byte, maxsz int) (*list.List, error) {
 		// FIXME: Find where the next prefix > minCopy starts,
 		// insert until then instead of always inserting minCopy
 		if len(remaining) <= minCopy {
-			estsz += len(remaining)+1
+			estsz += len(remaining) + 1
 			instructions.PushBack(insert(remaining))
 			remaining = nil
 			continue
@@ -104,7 +104,7 @@ func calculate(src, dst []byte, maxsz int) (*list.List, error) {
 
 		nextOffset := nextPrefixStart(index, dst)
 		if nextOffset >= 0 {
-			estsz += 1 + len(remaining)-nextOffset
+			estsz += 1 + len(remaining) - nextOffset
 			instructions.PushBack(insert(remaining[:nextOffset]))
 			remaining = remaining[nextOffset:]
 		} else {
@@ -187,11 +187,11 @@ func Calculate(w io.Writer, src, dst []byte, maxsz int) error {
 		return err
 	}
 	/*
-	if n, err := w.Write(buf.Bytes()); err != nil {
-		return err
-	} else if n != buf.Len() {
-		return fmt.Errorf("Could not write delta header")
-	}
+		if n, err := w.Write(buf.Bytes()); err != nil {
+			return err
+		} else if n != buf.Len() {
+			return fmt.Errorf("Could not write delta header")
+		}
 	*/
 
 	// Write the instructions themselves
@@ -308,15 +308,15 @@ func writeVarInt(w io.Writer, val int) error {
 		return err
 	}
 	/*
-	for val >= 128 {
+		for val >= 128 {
+			if err := w.WriteByte(byte(val & 127)); err != nil {
+				return err
+			}
+			val = val >> 7
+		}
 		if err := w.WriteByte(byte(val & 127)); err != nil {
 			return err
 		}
-		val = val >> 7
-	}
-	if err := w.WriteByte(byte(val & 127)); err != nil {
-		return err
-	}
 	*/
 	return nil
 }

--- a/git/delta/calculator_test.go
+++ b/git/delta/calculator_test.go
@@ -270,7 +270,6 @@ func TestSanityTest(t *testing.T) {
 		t.Errorf("Unexpected delta resolution: got %v want %v", val, target)
 	}
 
-	println("Doing delta that we want")
 	// "Large" delta, one which gave us problems with the git test suite..
 	base = make([]byte, 4096)
 

--- a/git/delta/calculator_test.go
+++ b/git/delta/calculator_test.go
@@ -3,6 +3,7 @@ package delta
 import (
 	"bytes"
 	"container/list"
+	"index/suffixarray"
 	"io/ioutil"
 	"testing"
 )
@@ -63,7 +64,8 @@ func TestCalculator(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		instructions, err := calculate(tc.src, tc.dst, -1)
+		idx := suffixarray.New(tc.src)
+		instructions, err := calculate(idx, tc.src, tc.dst, -1)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/git/delta/calculator_test.go
+++ b/git/delta/calculator_test.go
@@ -63,7 +63,10 @@ func TestCalculator(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		instructions := calculate(tc.src, tc.dst)
+		instructions, err := calculate(tc.src, tc.dst, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if identicalInstructions(tc.want, instructions) != true {
 			t.Errorf("%s", tc.label)
 		}
@@ -251,13 +254,36 @@ func TestSanityTest(t *testing.T) {
 	var delta bytes.Buffer
 	base := []byte("def")
 	target := []byte("defabc")
-	Calculate(&delta, base, target)
+	Calculate(&delta, base, target, -1)
 
 	resolved := NewReader(
 		bytes.NewReader(delta.Bytes()),
 		bytes.NewReader(base),
 	)
 	val, err := ioutil.ReadAll(&resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(val) != string(target) {
+		t.Errorf("Unexpected delta resolution: got %v want %v", val, target)
+	}
+
+	println("Doing delta that we want")
+	// "Large" delta, one which gave us problems with the git test suite..
+	base = make([]byte, 4096)
+
+	for i := range base {
+		base[i] = 'c'
+	}
+	target = []byte(string(base) + "foo")
+	delta.Reset()
+	Calculate(&delta, base, target, -1)
+
+	resolved = NewReader(
+		bytes.NewReader(delta.Bytes()),
+		bytes.NewReader(base),
+	)
+	val, err = ioutil.ReadAll(&resolved)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	//"runtime"
 	"sort"
 	"strings"
@@ -731,8 +732,14 @@ func IndexPack(c *Client, opts IndexPackOptions, r io.Reader) (idx PackfileIndex
 		idxname = basename + ".idx"
 	} else {
 		packhash, _ := indexfile.GetTrailer()
-		basename := fmt.Sprintf("%s/pack-%s", c.GitDir.File("objects/pack").String(), packhash)
+		basename := filepath.Join(c.ObjectDir, "pack", fmt.Sprintf("pack-%s", packhash))
 		idxname = basename + ".idx"
+
+		if opts.Keep != "" {
+			if err := ioutil.WriteFile(basename+".keep", []byte(opts.Keep+"\n"), 0755); err != nil {
+				return indexfile, err
+			}
+		}
 
 		if err := os.Rename(pack.Name(), basename+".pack"); err != nil {
 			return indexfile, err

--- a/git/init.go
+++ b/git/init.go
@@ -74,10 +74,11 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 
 	// These are all the directories created by a clean "git init"
 	// with the canonical git implementation
-	if err := os.MkdirAll(c.GitDir.String()+"/objects/pack", 0755); err != nil {
+	println("ObjectDir", c.ObjectDir)
+	if err := os.MkdirAll(filepath.Join(c.ObjectDir, "pack"), 0755); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(c.GitDir.String()+"/objects/info", 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(c.ObjectDir, "info"), 0755); err != nil {
 		return nil, err
 	}
 	if err := os.MkdirAll(c.GitDir.String()+"/info", 0755); err != nil {

--- a/git/init.go
+++ b/git/init.go
@@ -53,12 +53,22 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 			}
 			c.GitDir = GitDir(gd)
 			c.WorkDir = WorkDir(wd)
-			c.ObjectDir = c.GetObjectsDir().String()
+
+			od, err := filepath.Abs(c.GetObjectsDir().String())
+			if err != nil {
+				return nil, err
+			}
+			c.ObjectDir = od
 		} else {
 			c2, err := NewClient(dir+"/.git", dir)
 			if err != nil {
 				return nil, err
 			}
+			od, err := filepath.Abs(c2.ObjectDir)
+			if err != nil {
+				return nil, err
+			}
+			c2.ObjectDir = od
 			c = c2
 		}
 	} else {

--- a/git/init.go
+++ b/git/init.go
@@ -53,6 +53,7 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 			}
 			c.GitDir = GitDir(gd)
 			c.WorkDir = WorkDir(wd)
+			c.ObjectDir = c.GetObjectsDir().String()
 		} else {
 			c2, err := NewClient(dir+"/.git", dir)
 			if err != nil {
@@ -63,6 +64,7 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 	} else {
 		if c != nil {
 			c.GitDir = GitDir(dir)
+			c.ObjectDir = c.GetObjectsDir().String()
 		} else {
 			c2, err := NewClient(dir, "")
 			if err != nil {
@@ -74,7 +76,6 @@ func Init(c *Client, opts InitOptions, dir string) (*Client, error) {
 
 	// These are all the directories created by a clean "git init"
 	// with the canonical git implementation
-	println("ObjectDir", c.ObjectDir)
 	if err := os.MkdirAll(filepath.Join(c.ObjectDir, "pack"), 0755); err != nil {
 		return nil, err
 	}

--- a/git/packfile.go
+++ b/git/packfile.go
@@ -149,7 +149,11 @@ func (v VariableLengthInt) WriteVariable(w io.Writer, typ PackEntryType) error {
 		v = v >> 7
 
 	}
-	w.Write(b)
+	if n, err := w.Write(b); err != nil {
+		return err
+	} else if n != len(b) {
+		return fmt.Errorf("Could not write length to w")
+	}
 	return nil
 }
 

--- a/git/packfile.go
+++ b/git/packfile.go
@@ -129,7 +129,7 @@ func (p PackfileHeader) dataStream(r flate.Reader) (io.Reader, error) {
 
 type VariableLengthInt uint64
 
-func (v VariableLengthInt) WriteVariable(w io.Writer, typ PackEntryType) error {
+func (v VariableLengthInt) WriteVariable(w io.Writer, typ PackEntryType) (int, error) {
 	b := make([]byte, 0)
 	// Encode the type
 	theByte := byte(typ) << 4
@@ -149,12 +149,7 @@ func (v VariableLengthInt) WriteVariable(w io.Writer, typ PackEntryType) error {
 		v = v >> 7
 
 	}
-	if n, err := w.Write(b); err != nil {
-		return err
-	} else if n != len(b) {
-		return fmt.Errorf("Could not write length to w")
-	}
-	return nil
+	return w.Write(b)
 }
 
 // Reads a delta offset from the io.Reader, and returns both the value

--- a/git/packiterator.go
+++ b/git/packiterator.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"encoding/binary"
 )
@@ -53,7 +54,7 @@ func iteratePack(c *Client, r io.Reader, initcallback func(int), callback packIt
 		r = counter
 	} else {
 		var err error
-		pack, err = ioutil.TempFile(c.GitDir.File("objects/pack").String(), ".tmppackfile")
+		pack, err = ioutil.TempFile(filepath.Join(c.ObjectDir, "pack"), ".tmppackfile")
 		if err != nil {
 			return nil, err
 		}

--- a/git/packiterator.go
+++ b/git/packiterator.go
@@ -54,7 +54,13 @@ func iteratePack(c *Client, r io.Reader, initcallback func(int), callback packIt
 		r = counter
 	} else {
 		var err error
-		pack, err = ioutil.TempFile(filepath.Join(c.ObjectDir, "pack"), ".tmppackfile")
+		pdir := filepath.Join(c.ObjectDir, "pack")
+		if !File(pdir).Exists() {
+			if err := os.MkdirAll(pdir, 0755); err != nil {
+				return nil, err
+			}
+		}
+		pack, err = ioutil.TempFile(pdir, ".tmppackfile")
 		if err != nil {
 			return nil, err
 		}

--- a/git/packobjects.go
+++ b/git/packobjects.go
@@ -1,11 +1,19 @@
 package git
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	//"io/ioutil"
+	"log"
+	"os"
+	"runtime/pprof"
 
+	"compress/zlib"
 	"crypto/sha1"
 	"encoding/binary"
+
+	"github.com/driusan/dgit/git/delta"
 )
 
 type PackObjectsOptions struct {
@@ -17,12 +25,25 @@ type PackObjectsOptions struct {
 	DeltaBaseOffset bool
 }
 
+// Used for keeping track of the previous window objects to encode
+// their location with DeltaBaseOffset set
+type previousObject struct {
+	oid      Sha1
+	location int
+}
+
 // Writes a packfile to w of the objects objects from the client's
 // GitDir.
 func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1) (trailer Sha1, err error) {
-	if opts.Window != 0 {
-		return Sha1{}, fmt.Errorf("Deltas not supported")
+	f, err := os.Create("profile.cpu")
+	if err != nil {
+		log.Fatal("could not create CPU profile: ", err)
 	}
+	defer f.Close() // error handling omitted for example
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatal("could not start CPU profile: ", err)
+	}
+	defer pprof.StopCPUProfile()
 	sha := sha1.New()
 	w = io.MultiWriter(w, sha)
 	n, err := w.Write([]byte{'P', 'A', 'C', 'K'})
@@ -37,18 +58,66 @@ func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1
 	binary.Write(w, binary.BigEndian, uint32(2))
 	// Size
 	binary.Write(w, binary.BigEndian, uint32(len(objects)))
-	for _, obj := range objects {
-		s := VariableLengthInt(obj.UncompressedSize(c))
-
-		err := s.WriteVariable(w, obj.PackEntryType(c))
+	for i, obj := range objects {
+		objcontent, err := c.GetObject(obj)
 		if err != nil {
 			return Sha1{}, err
 		}
+		objbytes := objcontent.GetContent()
+		best := objbytes
+		otyp := obj.PackEntryType(c)
+		otyp1 := obj.PackEntryType(c)
+		var offref *Sha1
 
-		err = obj.CompressedWriter(c, w)
-		if err != nil {
+		// We don't bother trying to calculate how close the object
+		// is, we just blindly calculate a delta and calculate the
+		// size.
+
+		for tryidx := i - 1; tryidx >= 0 && tryidx > i-opts.Window; tryidx-- {
+			trytyp := obj.PackEntryType(c)
+			if trytyp != otyp1 {
+				continue
+			}
+			base, err := c.GetObject(objects[tryidx])
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				continue
+			}
+			basebytes := base.GetContent()
+			var newdelta bytes.Buffer
+			if err := delta.Calculate(&newdelta, basebytes, objbytes, len(best) / 2); err == nil {
+
+				if d := newdelta.Bytes(); len(d) < len(best) {
+					best = d
+					otyp = OBJ_REF_DELTA
+					offref = &objects[tryidx]
+				}
+			} else {
+				log.Println(err)
+			}
+		}
+		s := VariableLengthInt(len(best))
+
+		if err := s.WriteVariable(w, otyp); err != nil {
 			return Sha1{}, err
 		}
+
+		if offref != nil {
+			derefoff := Sha1(*offref)
+			if n, err := w.Write(derefoff[:]); err != nil {
+				return Sha1{}, err
+			} else if n != 20 {
+				panic("could not write ref offset")
+			}
+		}
+		zw := zlib.NewWriter(w)
+		if err != nil {
+			panic(err)
+		}
+		if _, err := zw.Write(best); err != nil {
+			return Sha1{}, err
+		}
+		zw.Close()
 	}
 	trail := sha.Sum(nil)
 	w.Write(trail)

--- a/git/packobjects.go
+++ b/git/packobjects.go
@@ -103,7 +103,6 @@ func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1
 		if ref != nil {
 			if opts.DeltaBaseOffset {
 				offset := pos - ref.location
-				println("Offset", pos-ref.location)
 				var buf [128]byte
 				n := binary.PutUvarint(buf[:], uint64(offset))
 				n, err := w.Write(buf[:n])

--- a/git/packobjects.go
+++ b/git/packobjects.go
@@ -2,12 +2,12 @@ package git
 
 import (
 	"bytes"
-	"fmt"
+	//	"fmt"
 	"io"
 	//"io/ioutil"
 	"log"
-	"os"
-	"runtime/pprof"
+	//	"os"
+	//"runtime/pprof"
 
 	"compress/zlib"
 	"crypto/sha1"
@@ -27,23 +27,16 @@ type PackObjectsOptions struct {
 
 // Used for keeping track of the previous window objects to encode
 // their location with DeltaBaseOffset set
-type previousObject struct {
+type packWindow struct {
 	oid      Sha1
 	location int
+	typ      PackEntryType
+	cache    []byte
 }
 
 // Writes a packfile to w of the objects objects from the client's
 // GitDir.
 func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1) (trailer Sha1, err error) {
-	f, err := os.Create("profile.cpu")
-	if err != nil {
-		log.Fatal("could not create CPU profile: ", err)
-	}
-	defer f.Close() // error handling omitted for example
-	if err := pprof.StartCPUProfile(f); err != nil {
-		log.Fatal("could not start CPU profile: ", err)
-	}
-	defer pprof.StopCPUProfile()
 	sha := sha1.New()
 	w = io.MultiWriter(w, sha)
 	n, err := w.Write([]byte{'P', 'A', 'C', 'K'})
@@ -58,6 +51,9 @@ func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1
 	binary.Write(w, binary.BigEndian, uint32(2))
 	// Size
 	binary.Write(w, binary.BigEndian, uint32(len(objects)))
+	var window []packWindow = make([]packWindow, 0, opts.Window)
+
+	pos := 12 // PACK + uint32 + uint32
 	for i, obj := range objects {
 		objcontent, err := c.GetObject(obj)
 		if err != nil {
@@ -66,36 +62,31 @@ func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1
 		objbytes := objcontent.GetContent()
 		best := objbytes
 		otyp := obj.PackEntryType(c)
-		otyp1 := obj.PackEntryType(c)
+		otypreal := obj.PackEntryType(c)
 		var offref *Sha1
 
 		// We don't bother trying to calculate how close the object
 		// is, we just blindly calculate a delta and calculate the
 		// size.
+		for _, tryobj := range window {
+			basebytes := tryobj.cache
+			if tryobj.typ != otypreal {
+				continue
+			}
 
-		for tryidx := i - 1; tryidx >= 0 && tryidx > i-opts.Window; tryidx-- {
-			trytyp := obj.PackEntryType(c)
-			if trytyp != otyp1 {
-				continue
-			}
-			base, err := c.GetObject(objects[tryidx])
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				continue
-			}
-			basebytes := base.GetContent()
 			var newdelta bytes.Buffer
-			if err := delta.Calculate(&newdelta, basebytes, objbytes, len(best) / 2); err == nil {
+			if err := delta.Calculate(&newdelta, basebytes, objbytes, len(best)/2); err == nil {
 
 				if d := newdelta.Bytes(); len(d) < len(best) {
 					best = d
 					otyp = OBJ_REF_DELTA
-					offref = &objects[tryidx]
+					offref = &tryobj.oid
 				}
 			} else {
 				log.Println(err)
 			}
 		}
+
 		s := VariableLengthInt(len(best))
 
 		if err := s.WriteVariable(w, otyp); err != nil {
@@ -118,6 +109,22 @@ func PackObjects(c *Client, opts PackObjectsOptions, w io.Writer, objects []Sha1
 			return Sha1{}, err
 		}
 		zw.Close()
+
+		if i < opts.Window {
+			window = append(window, packWindow{
+				oid:      obj,
+				location: n,
+				typ:      otypreal,
+				cache:    objbytes,
+			})
+		} else {
+			window[i%opts.Window] = packWindow{
+				oid:      obj,
+				location: pos,
+				typ:      otypreal,
+				cache:    objbytes,
+			}
+		}
 	}
 	trail := sha.Sum(nil)
 	w.Write(trail)

--- a/official-git/run-tests.sh
+++ b/official-git/run-tests.sh
@@ -58,7 +58,7 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1503.[5-7] t1503.10" # No support for @{suffix}
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t2018.[6-7] t2018.[9] t2018.1[5-8]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t3000.7"
 # Only the setup for pack-objects tests has been tested
-GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5300.1[6-9] t5300.2[0-9] t5300.3[0-3]"
+GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5300.1[7-9] t5300.2[0-9] t5300.3[0-3]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5512.1[1234] t5512.1[079] t5512.9 t5512.2[01234]" # 1[234] seem to get stuck in an infinite loop. The rest fail and need investigation.
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5510.[4-9] t5510.[1-7][0-9]" # Just the basic fetch tests are working for now
 export GIT_SKIP_TESTS

--- a/official-git/run-tests.sh
+++ b/official-git/run-tests.sh
@@ -58,7 +58,7 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t1503.[5-7] t1503.10" # No support for @{suffix}
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t2018.[6-7] t2018.[9] t2018.1[5-8]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t3000.7"
 # Only the setup for pack-objects tests has been tested
-GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5300.1[2-9] t5300.2[0-9] t5300.3[0-3]"
+GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5300.1[6-9] t5300.2[0-9] t5300.3[0-3]"
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5512.1[1234] t5512.1[079] t5512.9 t5512.2[01234]" # 1[234] seem to get stuck in an infinite loop. The rest fail and need investigation.
 GIT_SKIP_TESTS="$GIT_SKIP_TESTS t5510.[4-9] t5510.[1-7][0-9]" # Just the basic fetch tests are working for now
 export GIT_SKIP_TESTS


### PR DESCRIPTION
This adds support for calculating either ref of ofs deltas in git pack-objects. It fixes all of the tests of t5300-pack-object.sh of the official git test suite up until it starts testing with `git verify-pack` (which we don't currently have any implementation of.)

Other than deltas, this mostly involved improving support for `GIT_OBJECTS_DIRECTORY` throughout dgit and implementing `index-pack --keep`.