### PR TITLE
Fix regressions in git push, again

### DIFF
--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -87,7 +88,9 @@ func (s *smartHTTPConn) OpenConn(srv GitService) error {
 		req.SetBasicAuth(s.username, s.password)
 	}
 
-	req.Header.Set("Git-Protocol", "version=2")
+	if srv == UploadPackService {
+		req.Header.Set("Git-Protocol", "version=2")
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		// If we couldn't perform the request, there's probably a

--- a/git/httpconn.go
+++ b/git/httpconn.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 )
 


### PR DESCRIPTION
This fixes some regressions in git push caused by porting the
code to use git-send-pack instead of the old PackNegotiator https only
hack.

Our delta calculation isn't robust enough for the real world, so don't
use it in send-pack, and we weren't taking the "new branch" case into
consideration when checking if a push needs to be forced.