### PR TITLE
Fix dgit clone on Windows

### DIFF
--- a/git/consts.go
+++ b/git/consts.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package git

--- a/git/editor.go
+++ b/git/editor.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package git

--- a/git/file_ctime_netbsd.go
+++ b/git/file_ctime_netbsd.go
@@ -1,3 +1,4 @@
+//go:build netbsd
 // +build netbsd
 
 package git

--- a/git/file_ctime_other.go
+++ b/git/file_ctime_other.go
@@ -1,8 +1,5 @@
-// +build !dragonfly
-// +build !darwin
-// +build !linux
-// +build !openbsd
-// +build !netbsd
+//go:build !dragonfly && !darwin && !linux && !openbsd && !netbsd
+// +build !dragonfly,!darwin,!linux,!openbsd,!netbsd
 
 package git
 

--- a/git/file_ctime_unix.go
+++ b/git/file_ctime_unix.go
@@ -1,3 +1,4 @@
+//go:build dragonfly || linux || openbsd
 // +build dragonfly linux openbsd
 
 package git

--- a/git/file_inode_other.go
+++ b/git/file_inode_other.go
@@ -1,8 +1,5 @@
-// +build !dragonfly
-// +build !darwin
-// +build !linux
-// +build !openbsd
-// +build !netbsd
+//go:build !dragonfly && !darwin && !linux && !openbsd && !netbsd
+// +build !dragonfly,!darwin,!linux,!openbsd,!netbsd
 
 package git
 

--- a/git/file_inode_unix.go
+++ b/git/file_inode_unix.go
@@ -1,3 +1,4 @@
+//go:build dragonfly || linux || openbsd || netbsd
 // +build dragonfly linux openbsd netbsd
 
 package git

--- a/git/file_mtime.go
+++ b/git/file_mtime.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package git

--- a/git/indexpack.go
+++ b/git/indexpack.go
@@ -741,6 +741,7 @@ func IndexPack(c *Client, opts IndexPackOptions, r io.Reader) (idx PackfileIndex
 			}
 		}
 
+		pack.Close()
 		if err := os.Rename(pack.Name(), basename+".pack"); err != nil {
 			return indexfile, err
 		}

--- a/git/password_other.go
+++ b/git/password_other.go
@@ -1,4 +1,5 @@
-//+build !plan9
+//go:build !plan9
+// +build !plan9
 
 package git
 

--- a/git/progressf.go
+++ b/git/progressf.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package git

--- a/git/protectfs.go
+++ b/git/protectfs.go
@@ -1,5 +1,5 @@
-// +build !windows
-// +build !darwin
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package git
 

--- a/git/ssh_other.go
+++ b/git/ssh_other.go
@@ -1,11 +1,5 @@
-// +build !plan9
-// +build !dragonfly
-// +build !openbsd
-// +build !darwin
-// +build !freebsd
-// +build !netbsd
-// +build !solaris
-// +build !linux
+//go:build !plan9 && !dragonfly && !openbsd && !darwin && !freebsd && !netbsd && !solaris && !linux
+// +build !plan9,!dragonfly,!openbsd,!darwin,!freebsd,!netbsd,!solaris,!linux
 
 package git
 

--- a/git/ssh_unix.go
+++ b/git/ssh_unix.go
@@ -1,3 +1,4 @@
+//go:build dragonfly || openbsd || darwin || freebsd || netbsd || solaris || linux
 // +build dragonfly openbsd darwin freebsd netbsd solaris linux
 
 package git

--- a/go-get-modules-tests.sh
+++ b/go-get-modules-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "Running go get tests with Go modules enabled"


### PR DESCRIPTION
Windows will not allow a file to be renamed while it's still open. Add an explicit close before os.Rename, so that it doesn't fail because the file is already in use.

Resolves #281 